### PR TITLE
Fix long string overflow issue in message bubbles

### DIFF
--- a/src/app/components/chat/chat.component.scss
+++ b/src/app/components/chat/chat.component.scss
@@ -289,6 +289,8 @@ button {
 :host ::ng-deep .message-text {
   p {
     white-space: pre-line;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
## Summary

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/07a99269-8a5d-46be-8f7a-acae896b36a7" />

This PR fixes a layout issue where long unbroken strings (such as URLs) overflow or get visually cut off within message bubbles.
This improves readability and ensures the UI remains stable across various viewports.

## Problem
Long unbroken strings, such as URLs, may overflow or get visually cut off within the message bubble, making them difficult to read and negatively impacting the user experience.

## Solution
This change applies the following CSS rules to the message content area:

```css
overflow-wrap: break-word;
word-wrap: break-word; /* for legacy support */
```
These rules ensure that long words will break appropriately within the bubble, preserving the layout and improving readability.



## Screenshots
### Before
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/07a99269-8a5d-46be-8f7a-acae896b36a7" />

Long strings overflowed outside the bubble and were partially unreadable.

### After
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/71676ef6-d567-43c5-8857-02eebdcd5011" />

Long strings now wrap correctly within the message bubble and remain fully visible.