### PR TITLE
add min-width to generated images

### DIFF
--- a/src/app/components/chat/chat.component.scss
+++ b/src/app/components/chat/chat.component.scss
@@ -33,6 +33,7 @@
 
 .generated-image {
   max-width: 100%;
+  min-width: 40px;
   border-radius: 8px;
 }
 


### PR DESCRIPTION
I've found if generating SVG or an image format without defined width it won't show up unless there is a minimum width on the element.