### PR TITLE
allowing session state initilialization

### DIFF
--- a/src/app/components/session-tab/session-tab.component.html
+++ b/src/app/components/session-tab/session-tab.component.html
@@ -15,7 +15,27 @@
 -->
 
 <div class="session-wrapper">
+  <div class="new-session-container" style="padding: 16px; border-bottom: 1px solid #ccc;">
+    <h3>Create New Session with Initial Context</h3>
+    <p style="font-size: smaller; color: #666;">
+      Enter a valid JSON object to initialize the session's context state.
+    </p>
+    <textarea
+      [(ngModel)]="initialContextState"
+      placeholder="Enter initial context state as JSON (optional)"
+      rows="5"
+      style="width: 100%; margin-bottom: 8px; font-family: monospace; font-size: 12px;"></textarea>
+    <button (click)="createNewSession()" style="margin-bottom: 8px;">Create Session</button>
+    @if (jsonError) {
+      <div style="color: red; margin-bottom: 8px; white-space: pre-wrap;">{{ jsonError }}</div>
+    }
+  </div>
+
   <div class="session-tab-container" style="margin-top: 16px;">
+    <h4>Available Sessions</h4>
+    @if (sessionList.length === 0) {
+      <p style="padding-left: 16px; color: #777;">No sessions available for this agent yet.</p>
+    }
     @for (session of sessionList; track session) {
       <div (click)="getSession(session.id)" [ngClass]="session.id === sessionId ? 'session-item current': 'session-item'">
         <div class="session-info">

--- a/src/app/core/services/session.service.ts
+++ b/src/app/core/services/session.service.ts
@@ -28,11 +28,12 @@ export class SessionService {
   apiServerDomain = URLUtil.getApiServerBaseUrl();
   constructor(private http: HttpClient) {}
 
-  createSession(userId: string, appName: string) {
+  createSession(userId: string, appName: string, initialState?: object) {
     if (this.apiServerDomain != undefined) {
       const url =
           this.apiServerDomain + `/apps/${appName}/users/${userId}/sessions`;
-      return this.http.post<any>(url, null);
+      const body = initialState ? { "state": initialState } : null;
+      return this.http.post<any>(url, body);
     }
     return new Observable<any>();
   }


### PR DESCRIPTION
![Screenshot 2025-06-22 18 58 54](https://github.com/user-attachments/assets/3630979f-88d8-43d6-9578-5bcb39c750a4)

adk-web does not currently supports initializing the session state with data.
This is a important limitation, in particular when the root_agent is a Workflow agent (such as sequential).

This proposal show an example on how adk-web could support arbitrary initialization of the session state with a JSON dictionnary.