### PR TITLE
fix: Missing dependency 'string-to-color' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ngx-json-viewer": "^3.2.1",
     "ngx-markdown": "^19.1.1",
     "rxjs": "~7.8.0",
+    "string-to-color": "^2.2.2",
     "tslib": "^2.3.0",
     "uuid": "^11.1.0",
     "vanilla-jsoneditor": "^3.6.0",


### PR DESCRIPTION
I get this error running the web frontend:

✘ [ERROR] TS2307: Cannot find module 'string-to-color' or its corresponding type declarations. [plugin angular-compiler]

    src/app/components/chat/chat.component.ts:30:16:
      30 │ import stc from 'string-to-color';
         ╵                 ~~~~~~~~~~~~~~~~~