### PR TITLE
Health Endpoint for Kubernetes configuration

### DIFF
--- a/src/app/components/health/health.component.ts
+++ b/src/app/components/health/health.component.ts
@@ -15,24 +15,11 @@
  * limitations under the License.
  */
 
-import {NgModule} from '@angular/core';
-import {RouterModule, Routes} from '@angular/router';
-import {AppComponent} from './app.component';
-import {HealthComponent} from './components/health/health.component';
+import { Component } from '@angular/core';
 
-const routes: Routes = [
-  {
-    path: 'health',
-    component: HealthComponent,
-  },
-  {
-    path: '',
-    component: AppComponent,
-  }
-];
-
-@NgModule({
-  imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule],
+@Component({
+  selector: 'app-health',
+  template: 'ok',
+  standalone: true
 })
-export class AppRoutingModule {}
+export class HealthComponent {}


### PR DESCRIPTION
Hello, we deployed the ADK service in our cluster on kubernetes including the web-ui and when we deploy new versions the app is failing because it tries to look for an health endpoint, so this simple endpoint should fix kubernetes lookup and not impact on any development

Let me know if you think this can be merged, if not it's fine. Or if it needs any updates. 

thank you 