### PR TITLE
doc: update prerequisite to install npm first as it's required for an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Adk web is the built-in dev UI that comes along with adk for easier development 
 
 ## ✨ Prerequisite
 
-- **Install [Angular CLI](https://angular.dev/tools/cli)**
+- **Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)**
 
 - **Install [NodeJs](https://nodejs.org/en)**
 
-- **Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)**
+- **Install [Angular CLI](https://angular.dev/tools/cli)**
 
 - **Install [google-adk (Python)](https://github.com/google/adk-python)** 
 


### PR DESCRIPTION
followup on https://github.com/google/adk-docs/issues/553

since Angular cli is installed using npm, it makes sense to order the requirements such that npm is installed prior to install angular cli