### PR TITLE
Stop Agent Execution button in ADK web

### DIFF
--- a/src/app/components/chat/chat.component.html
+++ b/src/app/components/chat/chat.component.html
@@ -348,7 +348,17 @@
                   }"
                 >
                   @if (message.isLoading) {
-                    <mat-progress-bar class="loading-bar" mode="buffer"></mat-progress-bar>
+                    <div class="loading-container">
+                      <mat-progress-bar class="loading-bar" mode="buffer"></mat-progress-bar>
+                      <button
+                        mat-fab-button
+                        class="stop-button"
+                        (click)="stop()"
+                        matTooltip="Stop execution"
+                      >
+                        <mat-icon>stop</mat-icon>
+                      </button>
+                    </div>
                   }
                   @if (message.attachments) {
                     <div class="attachments">

--- a/src/app/components/chat/chat.component.scss
+++ b/src/app/components/chat/chat.component.scss
@@ -85,9 +85,29 @@
   background-color: #131314;
 }
 
+.loading-container {
+  display: flex;
+  align-items: center;
+  width: 150px;
+  justify-content: space-between;
+}
+
 .loading-bar {
   width: 100px;
   margin: 15px;
+}
+
+.stop-button {
+  width: 30px;
+  height: 30px;
+  background-color: #303030;
+
+  .mat-icon {
+    font-size: 18px;
+    color: white;
+    margin-left: -20px;
+    margin-top: -10px;
+  }
 }
 
 .chat-messages {

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -1389,6 +1389,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     this.currentSessionState = session.state;
   }
 
+  stop() {
+    this.agentService.stopSse();
+  }
+
   onNewSessionClick() {
     this.createSession();
     this.eventData.clear();


### PR DESCRIPTION
jules.google has implemented the request cancellation logic in `agent.service.ts` using an `AbortController` and added a `stopSse` method.

I have added the `stop()` method to `chat.component.ts` and connected it to the stop button.

The new stop functionality is implemented as a 1 shot by jules, and jules was not able to run the test suite.

This might be a concept more than it is a real PR, but capturing it as an artifact.  Feel free to reject.

Related to https://github.com/google/adk-web/issues/9 