### PR TITLE
bugfix: fixed 'Could not open the data' error

### DIFF
--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -241,7 +241,9 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     nonNullable: true,
   });
 
-  protected openBase64InNewTab = this.safeValuesService.openBase64InNewTab;
+  protected openBase64InNewTab(data: string, mimeType: string) {
+    this.safeValuesService.openBase64InNewTab(data, mimeType);
+  }
 
   // Load apps
   protected isLoadingApps: WritableSignal<boolean> = signal(false);


### PR DESCRIPTION
## Fix for 'Could not open the data' error on link-style-button click

<img width="496" height="186" alt="image" src="https://github.com/user-attachments/assets/4cbfd28b-42f6-4b2a-ae71-e583e2e0902b" />
<img width="462" height="179" alt="image" src="https://github.com/user-attachments/assets/1361ac07-e4c8-413f-a8ab-1a861fd44b17" />

### Problem
We see an error message: "Could not open the data. It might be invalid or too large. Check the browser console for errors." when clicking artifact links in the chat UI.

### Root Cause
The `openBase64InNewTab` function, which was responsible for opening base64 encoded data in a new tab, was being assigned directly from `this.safeValuesService.openBase64InNewTab` to a property in `src/app/components/chat/chat.component.ts`. When this property was invoked from the template, the `this` context within the `openBase64InNewTab` function (defined in `SafeValuesService`) was lost. Consequently, internal calls like `this.openBlobUrl(blob)` failed because `this` no longer referred to the `SafeValuesService` instance, leading to the reported error.

### Fix
**`src/app/components/chat/chat.component.ts`**: The property assignment `protected openBase64InNewTab = this.safeValuesService.openBase64InNewTab;` was replaced with a proper method:
    ```typescript
    protected openBase64InNewTab(dataUrl: string, mimeType: string) {
      this.safeValuesService.openBase64InNewTab(dataUrl, mimeType);
    }
    ```
    This ensures that when `openBase64InNewTab` is called from the template, it correctly invokes the `safeValuesService` method with the proper `this` context.