### PR TITLE
Updates font colors for eval tab dark mode

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -506,6 +506,8 @@ html.dark-theme {
   --builder-tool-item-background-color: rgba(255, 255, 255, 0.05);
   --builder-tool-item-border-color: rgba(255, 255, 255, 0.1);
   --builder-tool-item-hover-background-color: rgba(255, 255, 255, 0.1);
+  --mat-table-row-item-label-text-color: #fff;
+  --mat-table-header-headline-color: #fff;
 }
 
 // Light theme progress spinner and custom properties


### PR DESCRIPTION
The recent dark mode update made some eval tab fonts unreadable (black on dark background). This PR reverts the colors to white.

before: 
<img width="1680" height="1480" alt="image" src="https://github.com/user-attachments/assets/d7f8286a-feb0-48d7-87a8-e89969f4510d" />

after:
<img width="1524" height="1362" alt="image" src="https://github.com/user-attachments/assets/aadaeff7-b039-4a7e-8b24-0c1eb52bd234" />
