### PR TITLE
feat: Add Copy Markdown and Download PDF actions to chat messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@codemirror/lint": "^6.8.5",
         "@viz-js/viz": "^3.12.0",
         "codemirror": "^6.0.2",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^4.0.0",
         "ngx-json-viewer": "^3.2.1",
         "ngx-markdown": "^21.0.1",
         "ngx-vflow": "^1.16.4",
@@ -2321,7 +2323,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5958,11 +5959,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -6587,6 +6601,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -6896,6 +6919,26 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -7421,6 +7464,18 @@
         "webpack": "^5.1.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.47.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
@@ -7505,6 +7560,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -8856,6 +8920,17 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -8899,6 +8974,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -9369,6 +9450,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -9642,6 +9736,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -10185,6 +10285,23 @@
       "integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
       "bin": {
         "jsonrepair": "bin/cli.js"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/karma": {
@@ -12200,6 +12317,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12392,6 +12515,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "optional": true
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/picocolors": {
@@ -12720,6 +12850,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12803,6 +12943,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/regex-parser": {
       "version": "2.3.1",
@@ -12973,6 +13120,16 @@
       "integrity": "sha512-8h7ZcwxCBDKvchSWbWngJuSCqJGQ6nDuLLg+QcRyQDbX9jMWt+PpPeXAhSla0GOooEomk3lCprUpGkMdsLjKyg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -13986,6 +14143,16 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14134,6 +14301,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -14229,6 +14406,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/thingies": {
       "version": "2.5.0",
@@ -14576,6 +14762,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@codemirror/lint": "^6.8.5",
     "@viz-js/viz": "^3.12.0",
     "codemirror": "^6.0.2",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.0.0",
     "ngx-json-viewer": "^3.2.1",
     "ngx-markdown": "^21.0.1",
     "ngx-vflow": "^1.16.4",

--- a/src/app/components/markdown/markdown.component.html
+++ b/src/app/components/markdown/markdown.component.html
@@ -14,10 +14,75 @@
  limitations under the License.
 -->
 
-<markdown
-  [data]="text()"
-  [ngStyle]="{
-              'font-style': thought() ? 'italic' : 'normal',
-              color: thought() ? '#9aa0a6' : 'inherit'
-            }"
-></markdown>
+<div class="markdown-wrapper group" style="position: relative; padding-bottom: 2.5rem; min-width: 100px;">
+  
+  <markdown
+    #markdownContent
+    [data]="text()"
+    [ngStyle]="{
+      'font-style': thought() ? 'italic' : 'normal',
+      color: thought() ? '#9aa0a6' : 'inherit'
+    }"
+  ></markdown>
+
+  @if (text() && !thought()) {
+    <div style="
+        position: absolute; 
+        bottom: 0; 
+        right: 0; 
+        display: flex; 
+        gap: 4px; /* Space between buttons */
+    ">
+      
+      <button 
+        (click)="downloadPdf()"
+        [matTooltip]="pdfState === 'loading' ? 'Generating PDF...' : (pdfState === 'success' ? 'Downloaded!' : 'Download as PDF')"
+        matTooltipClass="white-tooltip" 
+        [disabled]="pdfState === 'loading'" 
+        style="
+          padding: 8px; 
+          opacity: 0.7; 
+          cursor: pointer;
+          border: none;
+          background: transparent;
+          color: inherit; 
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        "
+      >
+        @if (pdfState === 'loading') {
+          <mat-spinner diameter="18"></mat-spinner>
+        } @else if (pdfState === 'success') {
+          <mat-icon style="font-size: 18px; width: 18px; height: 18px; color: #4caf50;">check</mat-icon>
+        } @else {
+          <mat-icon style="font-size: 18px; width: 18px; height: 18px;">picture_as_pdf</mat-icon>
+        }
+      </button>
+
+      <button 
+        (click)="copyToClipboard()"
+        [matTooltip]="copyState === 'success' ? 'Copied!' : 'Copy raw Markdown'"
+        matTooltipClass="white-tooltip" 
+        style="
+          padding: 8px; 
+          opacity: 0.7; 
+          cursor: pointer;
+          border: none;
+          background: transparent;
+          color: inherit; 
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        "
+      >
+        @if (copyState === 'success') {
+          <mat-icon style="font-size: 16px; width: 16px; height: 16px; color: #4caf50;">check</mat-icon>
+        } @else {
+          <mat-icon style="font-size: 16px; width: 16px; height: 16px;">content_copy</mat-icon>
+        }
+      </button>
+
+    </div>
+  }
+</div>

--- a/src/app/components/markdown/markdown.component.ts
+++ b/src/app/components/markdown/markdown.component.ts
@@ -16,8 +16,15 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, input} from '@angular/core';
-import {MarkdownModule, provideMarkdown} from 'ngx-markdown';
+import {Component, input, ElementRef, ViewChild} from '@angular/core';
+import {MarkdownModule, provideMarkdown, MarkdownService} from 'ngx-markdown';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSnackBar } from '@angular/material/snack-bar';
+// 1. Add Spinner Module
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
 
 /**
  * Renders markdown text.
@@ -29,6 +36,9 @@ import {MarkdownModule, provideMarkdown} from 'ngx-markdown';
   imports: [
     CommonModule,
     MarkdownModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatProgressSpinnerModule // 2. Add to imports
   ],
   providers: [
     provideMarkdown(),
@@ -37,4 +47,94 @@ import {MarkdownModule, provideMarkdown} from 'ngx-markdown';
 export class MarkdownComponent {
   text = input('');
   thought = input(false);
+
+  @ViewChild('markdownContent', { static: false, read: ElementRef }) markdownElement!: ElementRef;
+
+  // 3. Add state trackers
+  pdfState: 'idle' | 'loading' | 'success' = 'idle';
+  copyState: 'idle' | 'success' = 'idle';
+
+  constructor(
+    private snackBar: MatSnackBar,
+    private markdownService: MarkdownService
+  ) {}
+
+  copyToClipboard() {
+    const content = this.text();
+    navigator.clipboard.writeText(content).then(() => {
+      
+      // 4. Update UI state to Success
+      this.copyState = 'success';
+      
+      this.snackBar.open('Copied raw Markdown to clipboard', 'Close', {
+        duration: 3000,
+        horizontalPosition: 'center',
+        verticalPosition: 'bottom'
+      });
+
+      // Reset back to normal after 2 seconds
+      setTimeout(() => {
+        this.copyState = 'idle';
+      }, 2000);
+
+    }).catch(err => {
+      console.error('Failed to copy:', err);
+    });
+  }
+
+  // FIXED: Added 'async' keyword
+  // 3. Updated Download PDF function
+  async downloadPdf() {
+    // 5. Start Loading
+    this.pdfState = 'loading';
+
+    const content = this.text();
+    
+    // A. Convert Markdown -> HTML
+    const rawHtml = await this.markdownService.parse(content);
+
+    // B. Create a temporary container
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = rawHtml;
+    
+    // C. Apply CSS for PDF rendering
+    // CRITICAL FIX: Use fixed position + z-index instead of top: -9999px
+    tempDiv.style.position = 'fixed';
+    tempDiv.style.top = '0';
+    tempDiv.style.left = '0';
+    tempDiv.style.zIndex = '-9999'; 
+    
+    tempDiv.style.width = '750px'; 
+    tempDiv.style.padding = '20px';
+    tempDiv.style.backgroundColor = '#ffffff'; 
+    tempDiv.style.color = '#000000'; 
+    tempDiv.style.fontFamily = 'Arial, sans-serif';
+    tempDiv.style.fontSize = '12px';
+    
+    document.body.appendChild(tempDiv);
+
+    // D. Generate PDF
+    const doc = new jsPDF('p', 'pt', 'a4');
+    
+    doc.html(tempDiv, {
+      callback: (pdf) => {
+        pdf.save('response.pdf');
+        document.body.removeChild(tempDiv);
+        
+        // 6. Update UI state to Success
+        this.pdfState = 'success';
+        
+        this.snackBar.open('PDF Downloaded!', 'Close', { duration: 3000 });
+
+        // Reset back to normal after 2 seconds
+        setTimeout(() => {
+          this.pdfState = 'idle';
+        }, 2000);
+      },
+      x: 10,
+      y: 10,
+      width: 550, 
+      windowWidth: 800 
+    });
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -47,6 +47,16 @@ markdown p {
   margin-block-end: 0.5em;
 }
 
+/* Add to src/styles.scss */
+
+.white-tooltip {
+  background-color: #ffffff !important;
+  color: #333333 !important; /* Dark text so it's readable on white */
+  font-size: 12px !important;
+  box-shadow: 0px 2px 5px rgba(0,0,0,0.2); /* Slight shadow for pop */
+  border-radius: 4px;
+}
+
 // Ensure menus and overlays appear above all other content
 .cdk-overlay-container {
   z-index: 9999 !important;


### PR DESCRIPTION
**Description**
This PR adds two action buttons to the bot's chat messages:
1. **Copy Markdown:** Copies the raw markdown text to the clipboard.
2. **Download PDF:** Generates a clean, white-background PDF of the message content.

 
 **Changes**
 * Updated `MarkdownComponent` to handle PDF generation using `jspdf`.
 * Added `MatProgressSpinner` for loading states during PDF generation.
 * Added specific styles to ensure tooltips are readable (white background).
 * Implemented "Gemini-style" floating action buttons below the chat bubble.
 
 
 **Screenshots**

 **1. Copy Markdown Text** <br>
<img width="600" height="auto" alt="Screenshot 2026-01-28 at 12 05 31 AM" src="https://github.com/user-attachments/assets/f5163ab8-988f-4b6c-b3a2-23271aa44e35" />

 **Result** <br>
<img width="600" height="auto" alt="Screenshot 2026-01-28 at 12 06 08 AM" src="https://github.com/user-attachments/assets/0f1d2cb7-9c17-4746-a634-0ee688e1bbac" />

 **2. Export Chat Response to PDF** <br>
<img width="600" height="auto" alt="Screenshot 2026-01-28 at 12 05 38 AM" src="https://github.com/user-attachments/assets/978e08a3-5a77-4fe3-a1b7-d5068d8ab094" />

 **Result** <br>
<img width="600" height="auto" alt="Screenshot 2026-01-28 at 12 05 47 AM" src="https://github.com/user-attachments/assets/96d1576b-feb1-49fa-a0ac-5ff1118af728" />

