### PR TITLE
feat: add Blob's display_name to Artifacts tab view

### DIFF
--- a/src/app/components/artifact-tab/artifact-tab.component.html
+++ b/src/app/components/artifact-tab/artifact-tab.component.html
@@ -25,7 +25,7 @@
           class="link-style-button"
           (click)="openArtifact(selectedArtifacts[i].data, selectedArtifacts[i].mimeType)"
           >
-          {{getArtifactName(artifactId)}}
+          {{getArtifactName(artifactId, selectedArtifacts[i].displayName)}}
         </button>
       </div>
       <div class="artifact-metadata">

--- a/src/app/components/artifact-tab/artifact-tab.component.ts
+++ b/src/app/components/artifact-tab/artifact-tab.component.ts
@@ -133,8 +133,8 @@ export class ArtifactTabComponent implements OnChanges {
     );
   }
 
-  protected getArtifactName(artifactId: string) {
-    return artifactId ?? DEFAULT_ARTIFACT_NAME;
+  protected getArtifactName(artifactId: string, displayName?: string) {
+    return displayName || artifactId || DEFAULT_ARTIFACT_NAME;
   }
 
   protected getDistinctArtifactIds() {

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -1225,7 +1225,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
             )
         .subscribe({
           next: (res) => {
-            const {mimeType, data} = res.inlineData ?? {};
+            const {mimeType, data, displayName} = res.inlineData ?? {};
             if (!mimeType || !data) {
               this.handleArtifactFetchFailure(message, artifactId, versionId);
               return;
@@ -1263,6 +1263,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
                   data: base64Data,
                   mimeType,
                   mediaType,
+                  displayName,
                 };
               }
               return artifact;

--- a/src/app/core/models/types.ts
+++ b/src/app/core/models/types.ts
@@ -21,6 +21,7 @@
 export declare interface Blob {
   mimeType?: string;
   data: string;
+  displayName?: string;
 }
 
 export declare interface FunctionCall {


### PR DESCRIPTION
Surfaces the Blob's `displayName` property in the Artifacts tab. When an artifact is saved with a `display_name` on the Blob, the UI now shows it instead of just the artifact key.
>>
>> Fixes https://github.com/google/adk-web/issues/292
>>
>> ## Changes
>>
>> - **`types.ts`**: Added `displayName` optional field to the `Blob` interface
>> - **`chat.component.ts`**: Extract `displayName` from `res.inlineData` in `renderArtifact()` and pass it through to the artifact object  
>> - **`artifact-tab.component.ts`**: Updated `getArtifactName()` to prefer `displayName` over `artifactId`
>> - **`artifact-tab.component.html`**: Pass `displayName` from selected artifact to `getArtifactName()`" --base main