### PR TITLE
fix: use userId from eval result to prevent session 404

### DIFF
--- a/src/app/components/eval-tab/eval-tab.component.ts
+++ b/src/app/components/eval-tab/eval-tab.component.ts
@@ -50,6 +50,7 @@ interface EvaluationResult {
   evalMetricResults: any[];
   overallEvalMetricResults: any[];
   evalMetricResultPerInvocation?: any[];
+  userId: string;
   sessionId: string;
   sessionDetails: any;
 }
@@ -385,7 +386,11 @@ export class EvalTabComponent implements OnInit, OnChanges {
         this.currentEvalResultBySet.get(this.selectedEvalSet)
             ?.filter((c) => c.evalId == evalId)[0];
     const sessionId = evalCaseResult!.sessionId;
-    this.sessionService.getSession(this.userId(), this.appName(), sessionId)
+    // Use the userId from the eval result instead of the component-level
+    // userId to avoid session 404 errors when the eval runner creates
+    // sessions with a different user_id than the UI default.
+    const evalUserId = evalCaseResult!.userId || this.userId();
+    this.sessionService.getSession(evalUserId, this.appName(), sessionId)
         .subscribe((res) => {
           this.addEvalCaseResultToEvents(res, evalCaseResult!);
           const session = this.fromApiResultToSession(res);
@@ -545,6 +550,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
                             evalMetricResults: result.evalMetricResults,
                             evalMetricResultPerInvocation:
                                 result.evalMetricResultPerInvocation,
+                            userId: result.userId,
                             sessionId: result.sessionId,
                             sessionDetails: result.sessionDetails,
                             overallEvalMetricResults:


### PR DESCRIPTION
## Summary

Fixes the session 404 error reported in [google/adk-python#5423](https://github.com/google/adk-python/issues/5423) (Issue 1).

### Problem

The eval tab component used the component-level `userId` input (which defaults to `"user"`) when fetching sessions for eval results via `getSession()`. If the eval runner created sessions with a different `user_id` (e.g., from the eval set's `session_input.user_id`), the session lookup would 404.

### Fix

1. Added `userId` field to the `EvaluationResult` interface
2. `getSession()` now uses `evalCaseResult.userId` (from the API response) instead of `this.userId()`, with a fallback to the component input if not present
3. Also captures `userId` in the history result mapping for consistency

### Companion PR

Server-side default alignment: [google/adk-python#5425](https://github.com/google/adk-python/pull/5425)

## Related

- Issue: google/adk-python#5423