### PR TITLE
fix: use toolConfirmation.payload as submit payload instead of tool args

### DIFF
--- a/src/app/components/long-running-response/long-running-response.ts
+++ b/src/app/components/long-running-response/long-running-response.ts
@@ -77,7 +77,11 @@ export class LongRunningResponseComponent implements OnChanges {
     
     if (this.isConfirmationRequest) {
       this.confirmationModel.confirmed = this.functionCall.args?.toolConfirmation?.confirmed || false;
-      this.confirmationModel.payload = JSON.stringify(this.functionCall.args?.originalFunctionCall?.args || {}, null, 2);
+      this.confirmationModel.payload = JSON.stringify(
+        this.functionCall.args?.toolConfirmation?.payload ??
+        this.functionCall.args?.originalFunctionCall?.args ??
+        {}, null, 2
+      );
       return;
     }
 


### PR DESCRIPTION
Fixes #439

## Problem

I was following the official docs at https://adk.dev/tools-custom/confirmation/#confirmation-definition
to implement a custom confirmation flow. When submitting the confirmation form, the agent
receives `{ days: 5 }` (the tool's original args) instead of `{ approved_days: 0 }` (the
payload schema defined by the developer), causing a `KeyError` crash.

## Root Cause

In `long-running-response.ts`, `initForm()` initializes `confirmationModel.payload` from
`originalFunctionCall.args` instead of `toolConfirmation.payload`. Since `onSend()` reads
`confirmationModel.payload` to build the submit request, the wrong payload gets sent.

## Fix

Read `toolConfirmation.payload` first when initializing `confirmationModel.payload`, with
a fallback to `originalFunctionCall.args` for cases where the developer did not provide a payload.

```typescript
// before
this.confirmationModel.payload = JSON.stringify(
  this.functionCall.args?.originalFunctionCall?.args || {}, null, 2
);

// after
this.confirmationModel.payload = JSON.stringify(
  this.functionCall.args?.toolConfirmation?.payload ??
  this.functionCall.args?.originalFunctionCall?.args ??
  {}, null, 2
);
```