### PR TITLE
fix: consolidate streaming thought partials into single bubble

### DIFF
--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -1272,7 +1272,11 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
 
         if (existingIndex >= 0) {
           const existingEvent = events[existingIndex];
-          
+
+          if (uiEvent.thought && existingEvent.thought) {
+            uiEvent.text = (existingEvent.text || '') + (uiEvent.text || '');
+          }
+
           // Preserve functionResponses and functionCalls if not present in new event
           if (!uiEvent.functionResponses || uiEvent.functionResponses.length === 0) {
             uiEvent.functionResponses = existingEvent.functionResponses;


### PR DESCRIPTION
## Summary

When thought/reasoning chunks arrive via SSE streaming (e.g., Claude extended thinking, Gemini with `thinking_config`), each partial `ReasoningChunk` renders as a **separate "Thought" bubble** in the Dev UI instead of consolidating into one.

The consolidation logic in `chat.component.ts` correctly locates the existing partial thought event (lines ~1246/1255), but `buildUiEventFromEvent` creates a fresh `UiEvent` with only the current chunk's text. On replacement (line 1285), the previously accumulated text is lost.

## Fix

Before replacing the existing thought event, prepend the existing thought text to the new event's text. This makes consecutive thought partials merge into a single progressively-growing bubble — matching the behavior of regular text streaming.

```typescript
if (uiEvent.thought && existingEvent.thought) {
  uiEvent.text = (existingEvent.text || '') + (uiEvent.text || '');
}
```

## Testing

- All 459 existing tests pass (`ng test --no-watch --browsers=ChromeHeadless`)
- Manually verified with `vertex_ai/claude-sonnet-4-6` via LiteLLM with `thinking={"type": "enabled", "budget_tokens": 10000}`

Fixes #443