### PR TITLE
fix: decode UTF-8 text artifacts correctly in getTextContent()

### DIFF
--- a/src/app/components/artifact-tab/artifact-tab.component.ts
+++ b/src/app/components/artifact-tab/artifact-tab.component.ts
@@ -158,7 +158,11 @@ export class ArtifactTabComponent implements OnChanges {
     if (commaIndex === -1) return '';
     const base64 = dataUrl.substring(commaIndex + 1);
     try {
-      return atob(base64);
+      // Use decodeURIComponent(escape(...)) to correctly reconstruct Unicode
+      // strings from UTF-8 byte sequences produced by renderArtifact()'s
+      // btoa(unescape(encodeURIComponent(text))) encoding.
+      // Plain atob() returns a Latin-1 string, causing garbled non-ASCII text.
+      return decodeURIComponent(escape(atob(base64)));
     } catch (e) {
       return 'Failed to decode text content';
     }


### PR DESCRIPTION
## Summary

- `getTextContent()` in `artifact-tab.component.ts` used `atob(base64)` which returns a Latin-1 byte string, causing non-ASCII characters (Japanese, Chinese, Korean, etc.) to appear garbled in the Artifacts tab preview and inline chat bubble.
- `renderArtifact()` encodes text via `btoa(unescape(encodeURIComponent(text)))` (standard UTF-8 → base64 pattern), but the decode side was missing the reverse step.
- Fix: replace `atob(base64)` with `decodeURIComponent(escape(atob(base64)))`.

## Test plan
- [ ] Save a text artifact containing non-ASCII characters (e.g. `"こんにちは"`) via `Part.from_text()`
- [ ] Verify the Artifacts tab preview displays the original text correctly
- [ ] Verify the inline chat bubble displays the original text correctly

Fixes #452