### PR TITLE
feat(eval): add live/audio eval support to the eval UI

### DIFF
--- a/src/app/components/chat-panel/chat-panel.component.html
+++ b/src/app/components/chat-panel/chat-panel.component.html
@@ -55,10 +55,20 @@
       </div>
     </div>
   }
-  @if (uiEvents.length === 0 && agentReadme) {
+  @if (uiEvents.length === 0 && agentReadme && !isEvalResult) {
   <div class="readme-content">
     <ng-container [ngComponentOutlet]="markdownComponent"
       [ngComponentOutletInputs]="{text: agentReadme, thought: false, isReadme: true}"></ng-container>
+  </div>
+  }
+  @if (uiEvents.length === 0 && isEvalResult) {
+  <div class="empty-eval-result">
+    <mat-icon>info_outline</mat-icon>
+    <p>This eval run produced no conversation turns.</p>
+    <p class="empty-eval-result-hint">
+      The run likely failed before any turns were recorded. Check the run status
+      and the server logs, then try running it again.
+    </p>
   </div>
   }
   @for (item of displayItems; track item; let i = $index) {

--- a/src/app/components/chat-panel/chat-panel.component.scss
+++ b/src/app/components/chat-panel/chat-panel.component.scss
@@ -366,6 +366,34 @@ button.send-message-btn {
   }
 }
 
+.empty-eval-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant);
+
+  mat-icon {
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+  }
+
+  .empty-eval-result-hint {
+    max-width: 360px;
+    font-size: 12px;
+    opacity: 0.85;
+  }
+}
+
 .branches-container {
   margin: 8px -20px;
   border-radius: 8px;

--- a/src/app/components/chat-panel/chat-panel.component.ts
+++ b/src/app/components/chat-panel/chat-panel.component.ts
@@ -145,6 +145,8 @@ export class ChatPanelComponent implements OnChanges, AfterViewInit {
   @Input() userId: string = '';
   @Input() sessionId: string = '';
   @Input() viewMode: 'events' | 'traces' = 'events';
+  // Renders the empty-run message instead of the README when there are no events.
+  @Input() isEvalResult: boolean = false;
   @Input() shouldShowEvent?: (uiEvent: UiEvent) => boolean;
   spansByInvocationId = new Map<string, Span[]>();
   displayItems: DisplayItem[] = [];

--- a/src/app/components/chat/chat.component.html
+++ b/src/app/components/chat/chat.component.html
@@ -467,7 +467,7 @@
       </div>
       } } @if (appName != "") {
 <div class="chat-sub-toolbar">
-  @if (!(uiEvents().length === 0 && agentReadme)) {
+  @if (!(uiEvents().length === 0 && agentReadme && chatType() !== 'eval-result')) {
   <mat-button-toggle-group [value]="viewMode()" (change)="onViewModeChange($event.value)" hideSingleSelectionIndicator>
     <mat-button-toggle value="events">Events</mat-button-toggle>
     <mat-button-toggle value="traces">Traces</mat-button-toggle>
@@ -625,6 +625,7 @@
             <app-chat-panel
               [appName]="appName"
               [agentReadme]="agentReadme"
+              [isEvalResult]="chatType() === 'eval-result'"
               [(userInput)]="userInput"
               [hideIntermediateEvents]="hideIntermediateEvents()"
               [uiEvents]="filteredUiEvents()"
@@ -670,6 +671,7 @@
             <app-chat-panel
               [appName]="appName"
               [agentReadme]="agentReadme"
+              [isEvalResult]="chatType() === 'eval-result'"
               [hideIntermediateEvents]="hideIntermediateEvents()"
               [uiEvents]="filteredUiEvents()"
               [showBranches]="showBranches()"
@@ -742,6 +744,25 @@
                             style="margin-top: 8px; border-top: 1px solid var(--mat-sys-outline-variant); padding-top: 6px; margin-bottom: 0;">
                             {{ desc }}</div>
                           }
+                          @if (metric.details?.explanation) {
+                          <div class="tooltip-explanation"
+                            style="margin-top: 8px; border-top: 1px solid var(--mat-sys-outline-variant); padding-top: 6px;">
+                            {{ metric.details.explanation }}</div>
+                          }
+                          @if (metric.details?.rubricScores?.length) {
+                          <div class="tooltip-rubrics"
+                            style="margin-top: 8px; border-top: 1px solid var(--mat-sys-outline-variant); padding-top: 6px;">
+                            <div class="tooltip-label" style="margin-bottom: 4px;">Rubrics</div>
+                            @for (rubric of metric.details.rubricScores; track $index) {
+                            <div class="tooltip-rubric" style="display: flex; gap: 6px; align-items: flex-start; margin-bottom: 4px;">
+                              <span class="material-symbols-outlined"
+                                [style.color]="rubricPassed(rubric) ? '#2e7d32' : 'var(--mat-sys-error)'"
+                                style="font-size: 14px; line-height: 16px;">{{ rubricPassed(rubric) ? 'check_circle' : 'cancel' }}</span>
+                              <span style="font-size: 11px;">{{ rubric.rationale || rubric.rubricId }}</span>
+                            </div>
+                            }
+                          </div>
+                          }
                         </div>
                       </div>
                     }
@@ -756,6 +777,7 @@
                   <app-chat-panel
                     [appName]="appName"
                     [agentReadme]="agentReadme"
+                    [isEvalResult]="chatType() === 'eval-result'"
                     [hideIntermediateEvents]="hideIntermediateEvents()"
                     [uiEvents]="filteredExpectedUiEvents()"
                     [showBranches]="showBranches()"
@@ -786,6 +808,7 @@
                   <app-chat-panel
                     [appName]="appName"
                     [agentReadme]="agentReadme"
+                    [isEvalResult]="chatType() === 'eval-result'"
                     [hideIntermediateEvents]="hideIntermediateEvents()"
                     [uiEvents]="filteredUiEvents()"
                     [showBranches]="showBranches()"
@@ -839,6 +862,7 @@
               <app-chat-panel
                 [appName]="appName"
                 [agentReadme]="agentReadme"
+                [isEvalResult]="chatType() === 'eval-result'"
                 [hideIntermediateEvents]="hideIntermediateEvents()"
                 [uiEvents]="filteredUiEvents()"
                 [showBranches]="showBranches()"

--- a/src/app/components/chat/chat.component.scss
+++ b/src/app/components/chat/chat.component.scss
@@ -1398,4 +1398,3 @@ app-canvas {
 .spinning {
   animation: spin 1s linear infinite;
 }
-

--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -294,6 +294,14 @@ describe('ChatComponent', () => {
       expect(component).toBeTruthy();
     });
 
+    it('rubricPassed reads backend verdict, falling back to score', () => {
+      expect(component.rubricPassed({verdict: true})).toBe(true);
+      expect(component.rubricPassed({verdict: false, score: 1})).toBe(false);
+      expect(component.rubricPassed({score: 1})).toBe(true);
+      expect(component.rubricPassed({score: 0})).toBe(false);
+      expect(component.rubricPassed({})).toBe(false);
+    });
+
     it(
         'should pre-fill user input from "q" query param only when app is selected',
         fakeAsync(() => {
@@ -725,6 +733,208 @@ describe('ChatComponent', () => {
         expect(component.sessionId).toBe('');
         expect(component['isViewOnlySession']()).toBeFalse();
         expect(component['canEditSession']()).toBeTrue();
+      });
+    });
+
+    describe('live eval result rendering', () => {
+      // A live run's persisted session is a noisy stream of audio chunks,
+      // partial transcriptions, and turn-complete markers.
+      const noisyLiveSessionEvents = [
+        {
+          id: 'e1',
+          author: 'user',
+          content: {
+            parts: [
+              {text: 'hello'},
+              {inlineData: {mimeType: 'audio/pcm', data: 'AAAA'}},
+            ],
+          },
+        },
+        {
+          id: 'e2',
+          author: 'bot',
+          content: {parts: [{inlineData: {mimeType: 'audio/pcm', data: 'BBBB'}}]},
+        },
+        {id: 'e3', author: 'bot', outputTranscription: {text: 'hi there'}},
+        {id: 'e4', author: 'bot', content: {parts: []}},
+      ];
+
+      // A valid base64 PCM chunk (4 bytes -> 2 16-bit samples).
+      const pcmChunk = btoa('\x01\x02\x03\x04');
+
+      // The clean per-invocation view the backend also returns. The first turn
+      // streams its model audio across many chunk events (mirroring a real live
+      // run) plus one real tool call.
+      const evalCaseResult = {
+        evalMetricResultPerInvocation: [
+          {
+            actualInvocation: {
+              userContent: {
+                parts: [
+                  {text: 'hello'},
+                  {inlineData: {mimeType: 'audio/pcm', data: pcmChunk}},
+                ],
+              },
+              finalResponse: {parts: [{text: 'hi there'}]},
+              intermediateData: {
+                invocationEvents: [
+                  {
+                    id: 'ie-fc',
+                    author: 'bot',
+                    content: {
+                      parts: [{functionCall: {name: 'do_thing', args: {}}}],
+                    },
+                  },
+                  {
+                    id: 'ie-a1',
+                    author: 'bot',
+                    content: {parts: [{inlineData: {mimeType: 'audio/pcm', data: pcmChunk}}]},
+                  },
+                  {
+                    id: 'ie-a2',
+                    author: 'bot',
+                    content: {parts: [{inlineData: {mimeType: 'audio/pcm', data: pcmChunk}}]},
+                  },
+                  {
+                    id: 'ie-partial',
+                    author: 'bot',
+                    partial: true,
+                    content: {parts: [{inlineData: {mimeType: 'audio/pcm', data: pcmChunk}}]},
+                  },
+                ],
+              },
+            },
+            evalMetricResults: [
+              {metricName: 'response_match_score', evalStatus: 1, score: 1, threshold: 0.7},
+            ],
+          },
+          {
+            actualInvocation: {
+              userContent: {parts: [{text: 'and again'}]},
+              finalResponse: {parts: [{text: 'sure thing'}]},
+              intermediateData: {},
+            },
+            evalMetricResults: [
+              {metricName: 'response_match_score', evalStatus: 2, score: 0.2, threshold: 0.7},
+            ],
+          },
+        ],
+      };
+
+      function liveResultSession() {
+        return {
+          id: SESSION_1_ID,
+          state: {},
+          events: noisyLiveSessionEvents,
+          isEvalResult: true,
+          evalCaseResult: {
+            ...evalCaseResult,
+            sessionDetails: {events: noisyLiveSessionEvents},
+          },
+        };
+      }
+
+      beforeEach(() => {
+        mockEventService.getTraceResponse.next([]);
+      });
+
+      it('detects a live eval result from audio/transcription session events',
+         () => {
+           expect(component['isLiveEvalResult'](liveResultSession().evalCaseResult))
+               .toBeTrue();
+           expect(component['isLiveEvalResult']({sessionDetails: {events: []}}))
+               .toBeFalse();
+         });
+
+      it('renders one bubble per turn (+tool call), not per raw audio chunk', () => {
+        component['updateWithSelectedSession'](liveResultSession() as any);
+        fixture.detectChanges();
+
+        // Turn 1: user + tool-call bot event + response bot event.
+        // Turn 2: user + response bot event. The many raw audio-chunk events
+        // (and the partial) are folded/dropped, NOT rendered as bubbles.
+        const roles = component.uiEvents().map((e: any) => e.role);
+        expect(roles).toEqual(['user', 'bot', 'bot', 'user', 'bot']);
+      });
+
+      it('renders transcript text and the tool call', () => {
+        component['updateWithSelectedSession'](liveResultSession() as any);
+        fixture.detectChanges();
+
+        const events = component.uiEvents();
+        expect(events[0]).toEqual(jasmine.objectContaining({role: 'user', text: 'hello'}));
+        // The tool call survives; audio-only chunk events do not.
+        expect(events[1].functionCalls?.[0]?.name).toBe('do_thing');
+        expect(events[2]).toEqual(jasmine.objectContaining({role: 'bot', text: 'hi there'}));
+      });
+
+      it('folds the turn\'s PCM chunks into one playable WAV clip', () => {
+        component['updateWithSelectedSession'](liveResultSession() as any);
+        fixture.detectChanges();
+
+        const events = component.uiEvents();
+        // Exactly one audio clip in the whole conversation (turn 1's response),
+        // not one per raw chunk.
+        const audioEvents = events.filter(
+            (e: any) => e.inlineData?.mimeType?.startsWith('audio/'));
+        expect(audioEvents.length).toBe(1);
+        // It is a playable WAV data URL (not raw audio/pcm).
+        expect(audioEvents[0].inlineData!.mimeType).toBe('audio/wav');
+        expect(audioEvents[0].inlineData!.data).toContain('data:audio/wav;base64,');
+        // No unplayable raw-PCM parts leak through.
+        expect(events.some((e: any) => e.inlineData?.mimeType === 'audio/pcm'))
+            .toBeFalse();
+        // The clip rides on turn 1's response bubble (which also has text).
+        expect(audioEvents[0].text).toBe('hi there');
+      });
+
+      it('attaches per-turn PASS/FAIL to live bot bubbles, as non-live does',
+         () => {
+           component['updateWithSelectedSession'](liveResultSession() as any);
+           fixture.detectChanges();
+
+           // Bubbles: [user, bot tool call, bot response] for the passing turn
+           // 1, then [user, bot response] for the failing turn 2.
+           const events = component.uiEvents();
+           expect(events[1].evalStatus).toBe(1);
+           expect(events[2].evalStatus).toBe(1);
+           expect(events[4].evalStatus).toBe(2);
+
+           // User bubbles are never annotated.
+           expect(events[0].evalStatus).toBeUndefined();
+           expect(events[3].evalStatus).toBeUndefined();
+         });
+
+      it('attaches the failing metric detail to the live response bubble', () => {
+        component['updateWithSelectedSession'](liveResultSession() as any);
+        fixture.detectChanges();
+
+        // Turn 2's response failed response_match_score; its bubble carries the
+        // "Match score / Threshold" detail, as in a non-live result.
+        const failedResponse = component.uiEvents()[4];
+        expect(failedResponse.failedMetric).toBe('response_match_score');
+        expect(failedResponse.evalScore).toBe(0.2);
+        expect(failedResponse.evalThreshold).toBe(0.7);
+      });
+
+      it('falls back to raw session events for a non-live eval result', () => {
+        const nonLive = {
+          id: SESSION_1_ID,
+          state: {},
+          events: [
+            {id: 'u', author: 'user', content: {parts: [{text: 'q'}]}},
+            {id: 'b', author: 'bot', content: {parts: [{text: 'a'}]}},
+          ],
+          isEvalResult: true,
+          evalCaseResult: {
+            evalMetricResultPerInvocation: [],
+            sessionDetails: {events: []},
+          },
+        };
+        component['updateWithSelectedSession'](nonLive as any);
+        fixture.detectChanges();
+
+        expect(component.uiEvents().map((e: any) => e.text)).toEqual(['q', 'a']);
       });
     });
 
@@ -1213,7 +1423,7 @@ describe('ChatComponent', () => {
       it('should save message', () => {
         expect(mockMessage.text).toBe(NEW_RESPONSE);
         expect(component.hasEvalCaseChanged()).toBe(true);
-        expect(component.updatedEvalCase!.conversation[0]
+        expect(component.updatedEvalCase!.conversation![0]
                    .finalResponse!.parts![0]!.text)
             .toBe(NEW_RESPONSE);
       });
@@ -1230,7 +1440,7 @@ describe('ChatComponent', () => {
       it('should delete message', () => {
         expect(component.uiEvents().length).toBe(0);
         expect(component.hasEvalCaseChanged()).toBe(true);
-        expect(component.updatedEvalCase!.conversation[0]
+        expect(component.updatedEvalCase!.conversation![0]
                    .finalResponse!.parts!.length)
             .toBe(0);
       });

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -73,6 +73,7 @@ import { ResizableDrawerDirective } from '../../directives/resizable-drawer.dire
 import { AddItemDialogComponent } from '../add-item-dialog/add-item-dialog.component';
 import { AgentStructureGraphDialogComponent } from '../agent-structure-graph-dialog/agent-structure-graph-dialog';
 import { getMediaTypeFromMimetype, MediaType } from '../artifact-tab/artifact-tab.component';
+import { pcmChunksToWavBase64 } from '../../core/utils/audio';
 import { BuilderTabsComponent } from '../builder-tabs/builder-tabs.component';
 import { CanvasComponent } from '../canvas/canvas.component';
 import { ChatPanelComponent } from '../chat-panel/chat-panel.component';
@@ -486,6 +487,15 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   getMetricDescription(metricName: string): string {
     const info = this.metricsInfo().find((m: any) => m.metricName === metricName);
     return info?.description || '';
+  }
+
+  /** Whether a single rubric result passed, per the backend verdict/score. */
+  rubricPassed(rubric: any): boolean {
+    if (rubric?.verdict !== undefined && rubric?.verdict !== null) {
+      return !!rubric.verdict;
+    }
+    // Fall back to score when no explicit boolean verdict is provided.
+    return typeof rubric?.score === 'number' && rubric.score >= 1;
   }
 
   getMetricMin(metricName: string): string {
@@ -943,6 +953,15 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
 
           const runId = `${this.appName}_${evalSetId}_${timestamp}`;
           console.log('loadSessionByUrlOrReset runId:', runId);
+
+          // Warm the metrics-info cache so metric tooltips render on direct load.
+          this.evalService.getMetricsInfo(this.appName)
+              .pipe(catchError((error) => {
+                console.error('Error fetching metrics info', error);
+                return of({metricsInfo: []});
+              }))
+              .subscribe();
+
           this.evalService.getEvalResult(this.appName, runId).subscribe((runResult) => {
             console.log('loadSessionByUrlOrReset runResult:', runResult);
             if (runResult) {
@@ -2416,6 +2435,23 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       event
     });
 
+    // Carry eval annotations onto the UiEvent so the badge templates render.
+    const evalAnnotationKeys: Array<keyof UiEvent> = [
+      'evalStatus',
+      'failedMetric',
+      'evalScore',
+      'evalThreshold',
+      'actualInvocationToolUses',
+      'expectedInvocationToolUses',
+      'actualFinalResponse',
+      'expectedFinalResponse',
+    ];
+    for (const key of evalAnnotationKeys) {
+      if (event[key] !== undefined) {
+        (uiEvent as any)[key] = event[key];
+      }
+    }
+
     if (event.errorCode || event.errorMessage) {
       uiEvent.error = {
         errorCode: event.errorCode,
@@ -2556,7 +2592,21 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     });
 
-    if (session.events && session.state) {
+    // A live (audio) eval result's raw session is a stream of audio chunks,
+    // partial transcriptions, and turn-complete markers; render the clean
+    // per-invocation view instead. See buildLiveActualEvents.
+    const evalCaseResult = (session as any).evalCaseResult;
+    const renderLiveActual =
+      (session as any).isEvalResult &&
+      evalCaseResult &&
+      this.isLiveEvalResult(evalCaseResult);
+
+    if (renderLiveActual) {
+      const liveEvents = this.buildLiveActualEvents(evalCaseResult);
+      liveEvents.forEach((event: any) => {
+        this.appendEventRow(event, false);
+      });
+    } else if (session.events && session.state) {
       session.events.forEach((event: any) => {
         this.appendEventRow(event, false);
 
@@ -2583,7 +2633,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(first())
       .subscribe((isInfinityMessageScrollingEnabled) => {
         if (!isInfinityMessageScrollingEnabled) {
-          this.populateMessages(session.events || []);
+          this.populateMessages(
+            renderLiveActual
+              ? this.buildLiveActualEvents(evalCaseResult)
+              : session.events || []);
         }
         this.loadTraceData();
       });
@@ -2612,22 +2665,8 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
           currentInvocationIndex++;
         } else {
           const invocationResult = invocationResults[currentInvocationIndex];
-          let evalStatus = 1;
-          let failedMetric = '';
-          let score = 1;
-          let threshold = 1;
-
-          if (invocationResult && invocationResult.evalMetricResults) {
-            for (const evalMetricResult of invocationResult.evalMetricResults) {
-              if (evalMetricResult.evalStatus === 2) {
-                evalStatus = 2;
-                failedMetric = evalMetricResult.metricName;
-                score = evalMetricResult.score;
-                threshold = evalMetricResult.threshold;
-                break;
-              }
-            }
-          }
+          const {evalStatus, failedMetric, score, threshold} =
+            this.computeInvocationVerdict(invocationResult);
 
           event.evalStatus = evalStatus;
 
@@ -2642,23 +2681,220 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     return res;
   }
 
+  // A turn fails as soon as any of its metrics fails; that metric's
+  // score/threshold feeds the bubble's detail row.
+  private computeInvocationVerdict(invocationResult: any):
+    {evalStatus: number, failedMetric: string, score: number, threshold: number} {
+    let evalStatus = 1;
+    let failedMetric = '';
+    let score = 1;
+    let threshold = 1;
+
+    for (const evalMetricResult of invocationResult?.evalMetricResults ?? []) {
+      if (evalMetricResult.evalStatus === 2) {
+        evalStatus = 2;
+        failedMetric = evalMetricResult.metricName;
+        score = evalMetricResult.score;
+        threshold = evalMetricResult.threshold;
+        break;
+      }
+    }
+
+    return {evalStatus, failedMetric, score, threshold};
+  }
+
   private addEvalFieldsToBotEvent(
     event: any, invocationResult: any, failedMetric: string, score: number,
     threshold: number) {
     event.failedMetric = failedMetric;
     event.evalScore = score;
     event.evalThreshold = threshold;
+    // expectedInvocation is absent for live (simulated-user) runs.
     if (event.failedMetric === 'tool_trajectory_avg_score') {
       event.actualInvocationToolUses = this.formatToolUses(
-        invocationResult.actualInvocation.intermediateData.toolUses);
+        invocationResult.actualInvocation?.intermediateData?.toolUses);
       event.expectedInvocationToolUses = this.formatToolUses(
-        invocationResult.expectedInvocation.intermediateData.toolUses);
+        invocationResult.expectedInvocation?.intermediateData?.toolUses);
     } else if (event.failedMetric === 'response_match_score') {
       event.actualFinalResponse =
-        invocationResult.actualInvocation.finalResponse.parts[0].text;
+        invocationResult.actualInvocation?.finalResponse?.parts?.[0]?.text;
       event.expectedFinalResponse =
-        invocationResult.expectedInvocation.finalResponse.parts[0]?.text;
+        invocationResult.expectedInvocation?.finalResponse?.parts?.[0]?.text;
     }
+  }
+
+  private isAudioPart(part: any): boolean {
+    return typeof part?.inlineData?.mimeType === 'string' &&
+      part.inlineData.mimeType.startsWith('audio/');
+  }
+
+  // A live run is inferred from audio parts or transcription events in the
+  // persisted session, which a non-live run never produces.
+  private isLiveEvalResult(evalCaseResult: any): boolean {
+    const events = evalCaseResult?.sessionDetails?.events;
+    if (!Array.isArray(events)) {
+      return false;
+    }
+    return events.some(
+      (e: any) => e?.inputTranscription || e?.outputTranscription ||
+        (e?.content?.parts ?? []).some((p: any) => this.isAudioPart(p)));
+  }
+
+  // Raw PCM parts are unplayable in a chat bubble, so keep only text/tool parts.
+  private stripAudioParts(content: any): any {
+    if (!content?.parts) {
+      return content;
+    }
+    const parts = content.parts.filter((p: any) => !this.isAudioPart(p));
+    return { ...content, parts };
+  }
+
+  // Order matters: the chunks are concatenated into a single clip.
+  private collectAudioChunks(contents: any[]): string[] {
+    const chunks: string[] = [];
+    for (const content of contents) {
+      for (const part of content?.parts ?? []) {
+        if (this.isAudioPart(part) && part.inlineData.data) {
+          chunks.push(part.inlineData.data);
+        }
+      }
+    }
+    return chunks;
+  }
+
+  // Builds chat events for a live result's actual conversation from the clean
+  // per-invocation view. Each turn contributes a user event, its intermediate
+  // (tool) events, and a response event whose many raw-PCM audio chunks are
+  // folded into one playable WAV clip; raw audio-chunk events are dropped.
+  private buildLiveActualEvents(evalCaseResult: any): any[] {
+    const invocationResults: any[] =
+      evalCaseResult?.evalMetricResultPerInvocation ?? [];
+    const events: any[] = [];
+
+    invocationResults.forEach((invocationResult, invocationIndex) => {
+      const actual = invocationResult?.actualInvocation;
+      if (!actual) {
+        return;
+      }
+
+      // Model audio for a turn is streamed across the intermediate events and
+      // (occasionally) the final response; collect every chunk to emit one clip.
+      const audioSources: any[] = [];
+
+      const turnEvents: any[] = [
+        ...this.buildLiveUserEvent(actual, invocationIndex),
+        ...this.buildLiveIntermediateEvents(actual, invocationIndex, audioSources),
+      ];
+
+      if (actual.finalResponse?.parts) {
+        audioSources.push(actual.finalResponse);
+      }
+      const responseEvent =
+        this.buildLiveResponseEvent(actual, invocationIndex, audioSources);
+      if (responseEvent) {
+        turnEvents.push(responseEvent);
+      }
+
+      // Parity with non-live results: every bot bubble in the turn carries the
+      // turn's PASS/FAIL verdict, and its final response carries the detail.
+      const {evalStatus, failedMetric, score, threshold} =
+        this.computeInvocationVerdict(invocationResult);
+      for (const turnEvent of turnEvents) {
+        if (turnEvent.author !== 'user') {
+          turnEvent.evalStatus = evalStatus;
+        }
+      }
+      if (responseEvent) {
+        this.addEvalFieldsToBotEvent(
+          responseEvent, invocationResult, failedMetric, score, threshold);
+      }
+
+      events.push(...turnEvents);
+    });
+
+    return events;
+  }
+
+  // The user turn renders transcript text only; the simulated user's audio is
+  // not surfaced here.
+  private buildLiveUserEvent(actual: any, invocationIndex: number): any[] {
+    if (!actual.userContent?.parts) {
+      return [];
+    }
+    return [{
+      author: 'user',
+      content: this.stripAudioParts(actual.userContent),
+      invocationIndex,
+    }];
+  }
+
+  // Emits the turn's tool events, appending each event's content to
+  // `audioSources`. Prefers the raw `invocationEvents` stream, falling back to
+  // the flattened `toolUses` list.
+  private buildLiveIntermediateEvents(
+    actual: any, invocationIndex: number, audioSources: any[]): any[] {
+    const events: any[] = [];
+
+    if (actual.intermediateData?.invocationEvents) {
+      let toolUseIndex = 0;
+      for (const event of actual.intermediateData.invocationEvents) {
+        // Partial transcription/audio markers are noise in the result view.
+        if (event?.partial) {
+          continue;
+        }
+        audioSources.push(event.content);
+        const stripped = this.stripAudioParts(event.content);
+        // Drop events whose only content was audio (now empty).
+        if (!stripped?.parts || stripped.parts.length === 0) {
+          continue;
+        }
+        const nextEvent: any = { ...event, content: stripped, invocationIndex };
+        if (stripped.parts[0]?.functionCall) {
+          nextEvent.toolUseIndex = toolUseIndex++;
+        }
+        events.push(nextEvent);
+      }
+    } else if (actual.intermediateData?.toolUses) {
+      let toolUseIndex = 0;
+      for (const toolUse of actual.intermediateData.toolUses) {
+        events.push({
+          author: 'bot',
+          content: { parts: [{ functionCall: { name: toolUse.name, args: toolUse.args } }] },
+          invocationIndex,
+          toolUseIndex: toolUseIndex++,
+        });
+        events.push({
+          author: 'bot',
+          content: { parts: [{ functionResponse: { name: toolUse.name } }] },
+          invocationIndex,
+        });
+      }
+    }
+
+    return events;
+  }
+
+  // Builds the response bubble, folding all of `audioSources`' PCM chunks into a
+  // single playable WAV part. Returns null when there's nothing to show. The
+  // caller annotates the returned event with the turn's eval verdict.
+  private buildLiveResponseEvent(
+    actual: any, invocationIndex: number, audioSources: any[]): any|null {
+    const wavBase64 = pcmChunksToWavBase64(this.collectAudioChunks(audioSources));
+    if (!actual.finalResponse?.parts && !wavBase64) {
+      return null;
+    }
+
+    const responseContent =
+      this.stripAudioParts(actual.finalResponse) ?? { parts: [] };
+    const parts = [...(responseContent.parts ?? [])];
+    if (wavBase64) {
+      parts.push({ inlineData: { mimeType: 'audio/wav', data: wavBase64 } });
+    }
+    return {
+      author: 'bot',
+      content: { ...responseContent, parts },
+      invocationIndex,
+    };
   }
 
   protected updateWithSelectedTest(testName: string, events: any[]) {
@@ -2732,7 +2968,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       for (const event of evalCase.events) {
         this.appendEventRow(event, false);
       }
-    } else {
+    } else if (evalCase.conversation?.length) {
       evalCase.events = [];
       let invocationIndex = 0;
 
@@ -2845,7 +3081,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
         message.functionCall.args = result;
 
         this.updatedEvalCase = structuredClone(this.evalCase!);
-        this.updatedEvalCase!.conversation[message.invocationIndex]
+        this.updatedEvalCase!.conversation![message.invocationIndex]
           .intermediateData!.toolUses![message.toolUseIndex]
           .args = result;
       }
@@ -2888,7 +3124,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       this.userEditEvalCaseMessage ? this.userEditEvalCaseMessage : ' ';
 
     this.updatedEvalCase = structuredClone(this.evalCase!);
-    this.updatedEvalCase!.conversation[message.invocationIndex]
+    this.updatedEvalCase!.conversation![message.invocationIndex]
       .finalResponse!.parts![message.finalResponsePartIndex] = {
       text: this.userEditEvalCaseMessage
     };
@@ -2910,7 +3146,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     this.uiEvents.update((uiEvents) => uiEvents.filter((m, i) => i !== index));
 
     this.updatedEvalCase = structuredClone(this.evalCase!);
-    this.updatedEvalCase!.conversation[message.invocationIndex]
+    this.updatedEvalCase!.conversation![message.invocationIndex]
       .finalResponse!.parts!.splice(message.finalResponsePartIndex, 1);
   }
 

--- a/src/app/components/content-bubble/content-bubble.component.ts
+++ b/src/app/components/content-bubble/content-bubble.component.ts
@@ -33,6 +33,7 @@ import {MARKDOWN_COMPONENT, MarkdownComponentInterface} from '../markdown/markdo
 import {ChatPanelMessagesInjectionToken} from '../chat-panel/chat-panel.component.i18n';
 import { URLUtil } from '../../../utils/url-util';
 import { ARTIFACT_SERVICE } from '../../core/services/interfaces/artifact';
+import { base64ToArrayBuffer, pcmToWavBlob } from '../../core/utils/audio';
 
 @Component({
   selector: 'app-content-bubble',
@@ -205,12 +206,12 @@ export class ContentBubbleComponent implements OnChanges {
       }
 
       if (base64Data) {
-        const buffer = this.base64ToArrayBuffer(base64Data);
+        const buffer = base64ToArrayBuffer(base64Data);
         const alignedLength = buffer.byteLength - (buffer.byteLength % 2);
         const slicedBuffer = buffer.slice(0, alignedLength);
         const sampleRate = 24000;
 
-        const wavBlob = this.pcmToWav(slicedBuffer, sampleRate, 1);
+        const wavBlob = pcmToWavBlob(slicedBuffer, sampleRate, 1);
 
         const reader = new FileReader();
         reader.onloadend = () => {
@@ -222,55 +223,5 @@ export class ContentBubbleComponent implements OnChanges {
     });
   }
 
-  base64ToArrayBuffer(base64: string): ArrayBuffer {
-    let cleanedBase64 = base64.replace(/\s/g, '');
-    const commaIndex = cleanedBase64.indexOf(',');
-    if (commaIndex !== -1) {
-      cleanedBase64 = cleanedBase64.substring(commaIndex + 1);
-    }
-    cleanedBase64 = cleanedBase64.replace(/-/g, '+').replace(/_/g, '/');
-    while (cleanedBase64.length % 4 !== 0) {
-      cleanedBase64 += '=';
-    }
-    const binaryString = window.atob(cleanedBase64);
-    const len = binaryString.length;
-    const bytes = new Uint8Array(len);
-    for (let i = 0; i < len; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes.buffer;
-  }
 
-  buf2hex(buffer: ArrayBuffer): string {
-    return Array.from(new Uint8Array(buffer))
-      .map(x => x.toString(16).padStart(2, '0'))
-      .join(' ');
-  }
-
-  pcmToWav(pcmBuffer: ArrayBuffer, sampleRate: number, numChannels: number): Blob {
-    const header = new ArrayBuffer(44);
-    const view = new DataView(header);
-
-    this.writeString(view, 0, 'RIFF');
-    view.setUint32(4, 36 + pcmBuffer.byteLength, true);
-    this.writeString(view, 8, 'WAVE');
-    this.writeString(view, 12, 'fmt ');
-    view.setUint32(16, 16, true);
-    view.setUint16(20, 1, true);
-    view.setUint16(22, numChannels, true);
-    view.setUint32(24, sampleRate, true);
-    view.setUint32(28, sampleRate * numChannels * 2, true);
-    view.setUint16(32, numChannels * 2, true);
-    view.setUint16(34, 16, true);
-    this.writeString(view, 36, 'data');
-    view.setUint32(40, pcmBuffer.byteLength, true);
-
-    return new Blob([header, pcmBuffer], { type: 'audio/wav' });
-  }
-
-  writeString(view: DataView, offset: number, string: string) {
-    for (let i = 0; i < string.length; i++) {
-      view.setUint8(offset + i, string.charCodeAt(i));
-    }
-  }
 }

--- a/src/app/components/eval-tab/eval-tab.component.html
+++ b/src/app/components/eval-tab/eval-tab.component.html
@@ -63,11 +63,17 @@
         <mat-icon>refresh</mat-icon>
       </button>
     }
+
+    @if (selectedEvalSet() !== '' && selectedEvalTab() === 'cases' && !selectedEvalCase()) {
+      <button mat-icon-button (click)="listEvalCases()" matTooltip="Refresh">
+        <mat-icon>refresh</mat-icon>
+      </button>
+    }
   </div>
   @if (selectedEvalSet() == '') {
 
   }
-  @if (evalsets.length == 0) {
+  @if (evalsets.length == 0 && selectedEvalSet() == '') {
   <div>
     <div class="empty-eval-info">
       <div class="info-title">
@@ -122,8 +128,11 @@
       </div>
       <div class="vertical-tabs-content">
         @if (evalRunning()) {
-        <div style="display: flex; justify-content: center; align-items: center; padding: 20px;">
-          <mat-progress-spinner mode="indeterminate" [diameter]="28" [strokeWidth]="3"></mat-progress-spinner>
+        <div class="eval-run-progress" style="display: flex; flex-direction: column; align-items: center; gap: 12px; padding: 28px 20px; text-align: center;">
+          <mat-progress-spinner mode="indeterminate" [diameter]="36" [strokeWidth]="3"></mat-progress-spinner>
+          <div class="eval-run-progress__title" style="font-weight: 500;">
+            Running eval…
+          </div>
         </div>
         } @else {
           @if (selectedEvalTab() === 'info') {
@@ -159,7 +168,8 @@
                   [checked]="selection.hasValue() && isAllSelected()"
                   [indeterminate]="selection.hasValue() && !isAllSelected()">
                 </mat-checkbox>
-                <button mat-button color="primary" (click)="openEvalConfigDialog()" [disabled]="evalCases.length == 0 || loadingMetrics()">
+                <button mat-button color="primary" (click)="runCasesFromToolbar()" [disabled]="evalCases.length == 0 || loadingMetrics()"
+                  matTooltip="Run evaluation">
                   @if (loadingMetrics()) {
                     <mat-progress-spinner mode="indeterminate" [diameter]="20" style="display: inline-block; vertical-align: middle; margin-right: 8px;"></mat-progress-spinner>
                   } @else {
@@ -169,12 +179,9 @@
                   i18n.runSelectedEvaluationButton }}
                 </button>
                 <button mat-button color="accent" (click)="openNewEvalCaseDialog()">
-                  <mat-icon>add</mat-icon> {{ i18n.addSessionToSetButtonPrefix }}
+                  <mat-icon>save_alt</mat-icon> {{ i18n.addSessionToSetButtonPrefix }}
                 </button>
                 <span class="spacer"></span>
-                <button mat-icon-button (click)="listEvalCases()" matTooltip="Refresh">
-                  <mat-icon>refresh</mat-icon>
-                </button>
               </div>
               @if (evalCases.length > 0) {
               <div class="eval-cases-list">
@@ -215,7 +222,8 @@
                       <div class="spacer"></div>
                       <div class="status-card__summary" style="width: 50px; text-align: center;">
                         <span [ngClass]="isMetricsSucceed(item.result) ? 'status-card__passed': 'status-card__failed'"
-                          style="font-family: monospace;">
+                          style="font-family: monospace;"
+                          matTooltip="Passed metrics / evaluated metrics. Color reflects the overall PASS/FAIL verdict.">
                           {{ getMetricsScore(item.result) }}
                         </span>
                       </div>
@@ -306,7 +314,8 @@
                       style="display: flex; justify-content: space-between; align-items: center;">
                       <span> {{ evalRes.evalId }} </span>
                       <span [ngClass]="isMetricsSucceed(evalRes) ? 'status-card__passed': 'status-card__failed'"
-                        style="font-family: monospace; width: 50px; text-align: center;">
+                        style="font-family: monospace; width: 50px; text-align: center;"
+                        matTooltip="Passed metrics / evaluated metrics. Color reflects the overall PASS/FAIL verdict.">
                         {{ getMetricsScore(evalRes) }}
                       </span>
                     </div>

--- a/src/app/components/eval-tab/eval-tab.component.spec.ts
+++ b/src/app/components/eval-tab/eval-tab.component.spec.ts
@@ -20,7 +20,7 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { EvalTabComponent } from './eval-tab.component';
 import { EvalService } from '../../core/services/eval.service';
 import { SessionService } from '../../core/services/session.service';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import {
@@ -37,20 +37,24 @@ describe('EvalTabComponent', () => {
   beforeEach(async () => {
     const evalService = jasmine.createSpyObj<EvalService>([
       'getEvalSets',
+      'getEvalSet',
       'listEvalCases',
       'runEval',
       'getEvalCase',
       'deleteEvalCase',
       'listEvalResults',
       'getEvalResult',
+      'getMetricsInfo',
     ]);
     evalService.getEvalSets.and.returnValue(of([]));
+    evalService.getEvalSet.and.returnValue(of({} as any));
     evalService.listEvalCases.and.returnValue(of([]));
     evalService.runEval.and.returnValue(of([]));
     evalService.getEvalCase.and.returnValue(of({} as any));
     evalService.deleteEvalCase.and.returnValue(of({} as any));
     evalService.listEvalResults.and.returnValue(of([]));
     evalService.getEvalResult.and.returnValue(of({} as any));
+    evalService.getMetricsInfo.and.returnValue(of({metricsInfo: []} as any));
 
     const sessionService = jasmine.createSpyObj<SessionService>([
       'getSession',
@@ -124,5 +128,204 @@ describe('EvalTabComponent', () => {
     fixture.detectChanges();
     
     expect(component.selectedHistoryRun()).toBeNull();
+  });
+
+  it('runs against the selected set id when one is selected', () => {
+    const evalService =
+        TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+    component.selectedEvalSet.set('my-set');
+
+    (component as any).runEval();
+
+    const args = evalService.runEval.calls.mostRecent().args;
+    expect(args[1]).toEqual('my-set');
+  });
+
+  it('forwards useLive and the user simulator config from the run dialog',
+     () => {
+       const evalService =
+           TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+       const dialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+       const userSimulatorConfig = {
+         type: 'llm_audio' as const,
+         audio_model: 'cloud_tts',
+         audio_model_configuration: {
+           speech_config: {
+             voice_config: {prebuilt_voice_config: {voice_name: 'en-US-Studio-O'}},
+             language_code: 'en-US',
+           },
+         },
+       };
+       dialog.open.and.returnValue({
+         afterClosed: () => of({
+           metrics: [{metricName: 'response_match_score', threshold: 0.7}],
+           useLive: true,
+           userSimulatorConfig,
+         }),
+       } as any);
+       component.selectedEvalSet.set('my-set');
+       evalService.runEval.calls.reset();
+
+       (component as any).openEvalConfigDialog();
+
+       expect((component as any).useLive).toBe(true);
+       const args = evalService.runEval.calls.mostRecent().args;
+       // runEval(appName, evalSetId, cases, metrics, useLive, simulatorConfig).
+       expect(args[4]).toBe(true);
+       expect(args[5]).toEqual(userSimulatorConfig);
+     });
+
+  it('runs a standard (non-live) run with no simulator config', () => {
+    const evalService =
+        TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+    const dialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+    dialog.open.and.returnValue({
+      afterClosed: () => of({
+        metrics: [{metricName: 'response_match_score', threshold: 0.7}],
+        useLive: false,
+        userSimulatorConfig: undefined,
+      }),
+    } as any);
+    component.selectedEvalSet.set('my-set');
+    evalService.runEval.calls.reset();
+
+    (component as any).openEvalConfigDialog();
+
+    const args = evalService.runEval.calls.mostRecent().args;
+    expect(args[4]).toBe(false);
+    expect(args[5]).toBeUndefined();
+  });
+
+  it('does not run when the run dialog is cancelled', () => {
+    const evalService =
+        TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+    const dialog = TestBed.inject(MatDialog) as jasmine.SpyObj<MatDialog>;
+    dialog.open.and.returnValue({afterClosed: () => of(null)} as any);
+    component.selectedEvalSet.set('my-persona-set');
+    evalService.runEval.calls.reset();
+
+    (component as any).runCasesFromToolbar();
+
+    expect(dialog.open).toHaveBeenCalled();
+    expect(evalService.runEval).not.toHaveBeenCalled();
+  });
+  it('fetches the eval session under the result user id, not the chat default',
+     () => {
+       const evalService =
+           TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+       const sessionService =
+           TestBed.inject(SESSION_SERVICE) as jasmine.SpyObj<SessionService>;
+       fixture.componentRef.setInput('appName', 'my-app');
+       fixture.componentRef.setInput('userId', 'chat-default-user');
+
+       // A fixed-script case (no conversation scenario) takes the session-fetch
+       // path rather than the live-result builder.
+       evalService.getEvalCase.and.returnValue(of({evalId: 'eval-1'} as any));
+       sessionService.getSession.calls.reset();
+       sessionService.getSession.and.returnValue(
+           of({id: 'sess-1', events: []} as any));
+
+       const evalCaseResult: any = {
+         sessionId: 'sess-1',
+         evalId: 'eval-1',
+         // The eval ran under a different user than the chat default.
+         userId: 'test_user_id',
+         evalMetricResultPerInvocation: [],
+       };
+
+       (component as any).getHistorySession(evalCaseResult, 'ts-1', 'set-1');
+
+       expect(sessionService.getSession)
+           .toHaveBeenCalledWith('test_user_id', 'my-app', 'sess-1');
+     });
+
+  it('still emits a session when the eval session fetch fails', () => {
+    const evalService =
+        TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+    const sessionService =
+        TestBed.inject(SESSION_SERVICE) as jasmine.SpyObj<SessionService>;
+    fixture.componentRef.setInput('appName', 'my-app');
+    fixture.componentRef.setInput('userId', 'chat-default-user');
+
+    evalService.getEvalCase.and.returnValue(of({evalId: 'eval-1'} as any));
+    sessionService.getSession.and.returnValue(
+        throwError(() => new Error('404')));
+
+    let emitted: any = null;
+    component.sessionSelected.subscribe((s: any) => {
+      emitted = s;
+    });
+
+    const evalCaseResult: any = {
+      sessionId: 'sess-1',
+      evalId: 'eval-1',
+      userId: 'test_user_id',
+      evalMetricResultPerInvocation: [],
+    };
+
+    (component as any).getHistorySession(evalCaseResult, 'ts-1', 'set-1');
+
+    // The result is still surfaced (with its metrics/status) instead of being
+    // silently dropped, so the chat shows the eval result rather than the
+    // agent README.
+    expect(emitted).toBeTruthy();
+    expect(emitted.id).toBe('sess-1');
+    expect(emitted.evalCaseResult).toBe(evalCaseResult);
+    expect(emitted.isEvalResult).toBe(true);
+  });
+
+  it('fetches metrics info when opening a historical eval result', () => {
+    const evalService =
+        TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+    const sessionService =
+        TestBed.inject(SESSION_SERVICE) as jasmine.SpyObj<SessionService>;
+    fixture.componentRef.setInput('appName', 'my-app');
+    fixture.componentRef.setInput('userId', 'chat-default-user');
+
+    evalService.getEvalCase.and.returnValue(of({evalId: 'eval-1'} as any));
+    evalService.getMetricsInfo.calls.reset();
+    sessionService.getSession.and.returnValue(
+        of({id: 'sess-1', events: []} as any));
+
+    const evalCaseResult: any = {
+      sessionId: 'sess-1',
+      evalId: 'eval-1',
+      userId: 'test_user_id',
+      evalMetricResultPerInvocation: [],
+    };
+
+    (component as any).getHistorySession(evalCaseResult, 'ts-1', 'set-1');
+
+    // Metric metadata (min/max/description) must be loaded so the metric block
+    // above the chat window can render full tooltips instead of missing values.
+    expect(evalService.getMetricsInfo).toHaveBeenCalledWith('my-app');
+  });
+
+  describe('selectEvalSet', () => {
+    it('does not fetch eval-set details when eval V2 is disabled', () => {
+      const evalService =
+          TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+      fixture.componentRef.setInput('appName', 'my-app');
+      component.isEvalV2Enabled.set(false);
+      evalService.getEvalSet.calls.reset();
+
+      component.selectEvalSet('my-set');
+
+      // The single eval-set detail endpoint only exists on the V2 dev server,
+      // so V1 must not call it (it would always 404).
+      expect(evalService.getEvalSet).not.toHaveBeenCalled();
+    });
+
+    it('fetches eval-set details when eval V2 is enabled', () => {
+      const evalService =
+          TestBed.inject(EVAL_SERVICE) as jasmine.SpyObj<EvalService>;
+      fixture.componentRef.setInput('appName', 'my-app');
+      component.isEvalV2Enabled.set(true);
+      evalService.getEvalSet.calls.reset();
+
+      component.selectEvalSet('my-set');
+
+      expect(evalService.getEvalSet).toHaveBeenCalledWith('my-app', 'my-set');
+    });
   });
 });

--- a/src/app/components/eval-tab/eval-tab.component.ts
+++ b/src/app/components/eval-tab/eval-tab.component.ts
@@ -29,9 +29,9 @@ import {MatTooltip} from '@angular/material/tooltip';
 import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {BehaviorSubject, of, forkJoin} from 'rxjs';
-import {catchError, first, switchMap} from 'rxjs/operators';
+import {catchError, finalize, first, switchMap} from 'rxjs/operators';
 
-import {DEFAULT_EVAL_METRICS, EvalCase, EvalMetric, Invocation, EvaluationResult} from '../../core/models/Eval';
+import {DEFAULT_EVAL_METRICS, EvalCase, EvalMetric, EvaluationResult, EvalStatus, UserSimulatorConfig} from '../../core/models/Eval';
 import {Session} from '../../core/models/Session';
 import {FeatureFlagService} from '../../core/services/feature-flag.service';
 import {EVAL_SERVICE} from '../../core/services/interfaces/eval';
@@ -133,7 +133,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
   evalsets: any[] = [];
   selectedEvalSet = signal<string>('');
   currentEvalSet = signal<any>(null);
-  
+
   evalHistorySorted = computed(() => {
     const evalHistory = this.appEvaluationResults[this.appName()]?.[this.selectedEvalSet()] || {};
     const keys = Object.keys(evalHistory).sort((a, b) => b.localeCompare(a));
@@ -155,7 +155,6 @@ export class EvalTabComponent implements OnInit, OnChanges {
     if (!caseObj) return [];
     const evalId = caseObj.evalId;
     const history = this.evalHistorySorted();
-    console.log('[DEBUG] caseHistory history:', history.map(h => h.timestamp), 'selectedHistoryRun:', this.selectedHistoryRun());
     return history.map(run => {
       const result = run.evaluationResults.evaluationResults.find((r: any) => r.evalId === evalId);
       return { timestamp: run.timestamp, result: result };
@@ -176,6 +175,9 @@ export class EvalTabComponent implements OnInit, OnChanges {
   evalRunning = signal(false);
   loadingMetrics = signal(false);
   evalMetrics: EvalMetric[] = DEFAULT_EVAL_METRICS;
+  useLive = false;
+  // Audio user simulator config for the next run, set from the run dialog.
+  pendingUserSimulatorConfig: UserSimulatorConfig|null = null;
   isEvalV2Enabled = signal(false);
 
   // Key: evalSetId
@@ -207,6 +209,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
       this.getEvaluationResult();
     }
   }
+
   ngOnInit(): void {
     this.flagService.isEvalV2Enabled()
       .pipe(first())
@@ -324,24 +327,40 @@ export class EvalTabComponent implements OnInit, OnChanges {
         });
   }
 
+  /** Cases-tab Run button. */
+  protected runCasesFromToolbar() {
+    this.openEvalConfigDialog();
+  }
+
   runEval() {
     this.evalRunning.set(true);
+    const evalSetId = this.selectedEvalSet();
+    let runFailed = false;
     this.evalService
         .runEval(
             this.appName(),
-            this.selectedEvalSet(),
+            evalSetId,
             this.selection.selected.length === 0 ? this.dataSource.data : this.selection.selected,
             this.evalMetrics,
+            this.useLive,
+            this.pendingUserSimulatorConfig ?? undefined,
             )
         .pipe(catchError((error) => {
+          runFailed = true;
           if (error.error?.detail?.includes('not installed')) {
             this.evalNotInstalledMsg.emit(error.error.detail);
           }
           return of([]);
         }))
         .subscribe((res) => {
-           this.currentEvalResultBySet.set(this.selectedEvalSet(), res);
-
+          // On failure, stop the spinner here; otherwise getEvaluationResult
+          // clears it once results are loaded.
+          if (runFailed) {
+            this.evalRunning.set(false);
+            this.changeDetectorRef.detectChanges();
+            return;
+          }
+          this.currentEvalResultBySet.set(evalSetId, res);
           this.getEvaluationResult(true);
           this.changeDetectorRef.detectChanges();
         });
@@ -424,7 +443,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
     const invocationResults = evalCaseResult.evalMetricResultPerInvocation!;
     let currentInvocationIndex = -1;
 
-    if (invocationResults) {
+    if (invocationResults && res?.events) {
       for (let i = 0; i < res.events.length; i++) {
         const event = res.events[i];
         if (event.author === 'user') {
@@ -438,8 +457,8 @@ export class EvalTabComponent implements OnInit, OnChanges {
           
           if (invocationResult && invocationResult.evalMetricResults) {
             for (const evalMetricResult of invocationResult.evalMetricResults) {
-              if (evalMetricResult.evalStatus === 2) {
-                evalStatus = 2;
+              if (evalMetricResult.evalStatus === EvalStatus.FAILED) {
+                evalStatus = EvalStatus.FAILED;
                 failedMetric = evalMetricResult.metricName;
                 score = evalMetricResult.score;
                 threshold = evalMetricResult.threshold;
@@ -496,13 +515,26 @@ export class EvalTabComponent implements OnInit, OnChanges {
         this.currentEvalResultBySet.get(this.selectedEvalSet())
             ?.filter((c) => c.evalId == evalId)[0];
     const sessionId = evalCaseResult!.sessionId;
-    this.sessionService.getSession(this.userId(), this.appName(), sessionId)
+    const sessionUserId = this.evalSessionUserId(evalCaseResult);
+    this.sessionService.getSession(sessionUserId, this.appName(), sessionId)
+        .pipe(catchError((error) => {
+          console.error('Error fetching eval session', error);
+          return of(null);
+        }))
         .subscribe((res) => {
+          if (!res) {
+            return;
+          }
           this.addEvalCaseResultToEvents(res, evalCaseResult!);
           const session = this.fromApiResultToSession(res);
 
           this.sessionSelected.emit(session);
         });
+  }
+
+  /** Eval sessions are saved under the user id the eval ran as, not the chat default. */
+  private evalSessionUserId(evalCaseResult: any): string {
+    return evalCaseResult?.userId || this.userId();
   }
 
   toggleEvalHistoryButton() {
@@ -541,18 +573,25 @@ export class EvalTabComponent implements OnInit, OnChanges {
 
   private getMetricsCounts(evalRes: any): {passed: number, total: number} {
     if (!evalRes) return {passed: 0, total: 0};
-    
+
     let passed = 0;
     let total = 0;
-    
+
+    // Excludes NOT_EVALUATED so the ratio reads "passed / evaluated".
+    const tally = (results: any[]) => {
+      for (const r of results) {
+        if (r.evalStatus === EvalStatus.NOT_EVALUATED) continue;
+        total += 1;
+        if (r.evalStatus === EvalStatus.PASSED) passed += 1;
+      }
+    };
+
     if (evalRes.evalMetricResults && evalRes.evalMetricResults.length > 0) {
-      passed = evalRes.evalMetricResults.filter((r: any) => r.evalStatus === 1).length;
-      total = evalRes.evalMetricResults.length;
+      tally(evalRes.evalMetricResults);
     } else if (evalRes.evalMetricResultPerInvocation) {
       for (const inv of evalRes.evalMetricResultPerInvocation) {
         if (inv.evalMetricResults) {
-          passed += inv.evalMetricResults.filter((r: any) => r.evalStatus === 1).length;
-          total += inv.evalMetricResults.length;
+          tally(inv.evalMetricResults);
         }
       }
     }
@@ -564,9 +603,10 @@ export class EvalTabComponent implements OnInit, OnChanges {
     return `${passed}/${total}`;
   }
 
+  // Uses the backend verdict so the score color stays in sync with the
+  // PASS/FAIL status, rather than recomputing from counts.
   protected isMetricsSucceed(evalRes: any): boolean {
-    const {passed, total} = this.getMetricsCounts(evalRes);
-    return passed === total;
+    return evalRes?.finalEvalStatus === EvalStatus.PASSED;
   }
 
   protected formatTimestamp(timestamp: number|string): string {
@@ -613,16 +653,42 @@ export class EvalTabComponent implements OnInit, OnChanges {
     return this.getEvalHistoryOfCurrentSet()[timestamp].evaluationResults;
   }
 
-  getHistorySession(evalCaseResult: EvaluationResult, timestamp: string) {
+  getHistorySession(
+      evalCaseResult: EvaluationResult, timestamp: string,
+      evalSetId: string = this.selectedEvalSet()) {
     const sessionId = evalCaseResult.sessionId;
     const evalId = evalCaseResult.evalId;
-    
+
     this.selectedHistoryRun.set(timestamp);
-    
-    this.evalService.getEvalCase(this.appName(), this.selectedEvalSet(), evalId)
+
+    // Warm the metrics-info cache so metric tooltips render on direct load.
+    this.evalService.getMetricsInfo(this.appName())
+        .pipe(catchError((error) => {
+          console.error('Error fetching metrics info', error);
+          return of({metricsInfo: []});
+        }))
+        .subscribe();
+
+    this.evalService.getEvalCase(this.appName(), evalSetId, evalId)
         .subscribe((evalCase) => {
-          this.sessionService.getSession(this.userId(), this.appName(), sessionId)
+          const sessionUserId = this.evalSessionUserId(evalCaseResult);
+          this.sessionService.getSession(sessionUserId, this.appName(), sessionId)
+              .pipe(catchError((error) => {
+                console.error('Error fetching eval session', error);
+                return of(null);
+              }))
               .subscribe((res) => {
+                if (!res) {
+                  // Surface the result (metrics/status) even when the session
+                  // can't be loaded, rather than falling back to the README.
+                  const session = this.fromApiResultToSession(
+                      {id: sessionId, userId: sessionUserId, events: []});
+                  (session as any).evalCase = evalCase;
+                  (session as any).evalCaseResult = evalCaseResult;
+                  (session as any).timestamp = timestamp;
+                  this.sessionSelected.emit(session);
+                  return;
+                }
                 this.addEvalCaseResultToEvents(res, evalCaseResult);
                 const session = this.fromApiResultToSession(res);
                 (session as any).evalCase = evalCase;
@@ -632,6 +698,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
               });
         });
   }
+
 
   protected getEvalCase(element: any) {
     this.evalService.getEvalCase(this.appName(), this.selectedEvalSet(), element)
@@ -737,13 +804,20 @@ export class EvalTabComponent implements OnInit, OnChanges {
             if (!ids || ids.length === 0) return of([]);
             const observables = ids.map(id => this.evalService.getEvalResult(this.appName(), id));
             return forkJoin(observables);
-          })
+          }),
+          // Always clear the running state, even on empty/error paths, so the
+          // spinner never gets stuck.
+          finalize(() => {
+            this.evalRunning.set(false);
+            this.changeDetectorRef.detectChanges();
+          }),
         )
         .subscribe((results: any[]) => {
           if (results.length === 0) return;
-          
+
           let latestTimestamp = '';
-          
+          let latestEvalSetId = '';
+
           for (const res of results) {
             if (!this.appEvaluationResults[this.appName()]) {
               this.appEvaluationResults[this.appName()] = {};
@@ -756,6 +830,7 @@ export class EvalTabComponent implements OnInit, OnChanges {
             const timeStamp = res.creationTimestamp;
             if (!latestTimestamp || timeStamp > latestTimestamp) {
               latestTimestamp = timeStamp;
+              latestEvalSetId = res.evalSetId;
             }
 
             const uiEvaluationResult: UIEvaluationResult = {
@@ -770,21 +845,37 @@ export class EvalTabComponent implements OnInit, OnChanges {
                   sessionId: result.sessionId,
                   sessionDetails: result.sessionDetails,
                   overallEvalMetricResults: result.overallEvalMetricResults ?? [],
+                  userId: result.userId,
                 };
               }),
             };
 
             this.appEvaluationResults[this.appName()][res.evalSetId][timeStamp] = uiEvaluationResult;
           }
-          
+
           this.changeDetectorRef.detectChanges();
-          
+
           if (navigateToLatest && latestTimestamp) {
             this.selectedEvalTab.set('history');
             this.selectedHistoryRun.set(latestTimestamp);
+            // Open the latest run directly so the result shows without an
+            // extra click, replacing the in-progress indicator.
+            this.openLatestRunResult(latestEvalSetId, latestTimestamp);
           }
-          this.evalRunning.set(false);
         });
+  }
+
+  // Opens the latest run's result in the chat window, but only for a
+  // single-case set (for multi-case sets, stay on the history list).
+  private openLatestRunResult(evalSetId: string, timestamp: string) {
+    const uiResult =
+        this.appEvaluationResults[this.appName()]?.[evalSetId]?.[timestamp];
+    const caseResults = uiResult?.evaluationResults ?? [];
+    if (caseResults.length !== 1) {
+      return;
+    }
+    this.getHistorySession(
+        caseResults[0] as EvaluationResult, timestamp, evalSetId);
   }
 
   protected openEvalConfigDialog() {
@@ -805,12 +896,21 @@ export class EvalTabComponent implements OnInit, OnChanges {
           },
         });
 
-        dialogRef.afterClosed().subscribe((evalMetrics) => {
-          if (!!evalMetrics) {
-            this.evalMetrics = evalMetrics;
-            window.localStorage.setItem('adk_eval_metrics_selection', JSON.stringify(evalMetrics));
-            this.runEval();
+        dialogRef.afterClosed().subscribe((result) => {
+          if (!result) {
+            return;
           }
+
+          this.evalMetrics = result.metrics;
+          this.useLive = !!result.useLive;
+          this.pendingUserSimulatorConfig = result.userSimulatorConfig ?? null;
+
+          // Persist the user's metric selection so it is remembered next time.
+          window.localStorage.setItem(
+              'adk_eval_metrics_selection',
+              JSON.stringify(result.metrics));
+
+          this.runEval();
         });
       });
   }

--- a/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.html
+++ b/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.html
@@ -1,4 +1,5 @@
 <!--
+ @license
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +14,75 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<div class="dialog-container">
-  <h2 mat-dialog-title class="dialog-title">EVALUATION METRICS</h2>
+
+<div class="run-eval-config-dialog">
+  <h2 mat-dialog-title class="dialog-title">Run evaluation</h2>
   <mat-dialog-content>
+    <!-- ---- Run mode ---- -->
+    <form [formGroup]="runForm" class="run-mode-form">
+      <mat-button-toggle-group
+        formControlName="runMode"
+        class="run-mode-toggle"
+        aria-label="Evaluation run mode">
+        <mat-button-toggle value="standard">
+          <mat-icon>chat</mat-icon> Standard
+        </mat-button-toggle>
+        <mat-button-toggle value="live">
+          <mat-icon>graphic_eq</mat-icon> Live
+        </mat-button-toggle>
+      </mat-button-toggle-group>
+      <span class="option-hint">
+        @if (isLive) {
+          Streams input for live, real-time interaction with the agent.
+        } @else {
+          Evaluates each turn as a single request and response.
+        }
+      </span>
+    </form>
+
+    <!-- ---- Live input modality + audio user simulation ---- -->
+    @if (isLive) {
+      <form [formGroup]="runForm" class="run-options">
+        <div class="run-option-row modality-row">
+          <mat-form-field appearance="outline" class="modality-field">
+            <mat-label>Input modality</mat-label>
+            <mat-select formControlName="inputModality">
+              <mat-option value="audio">Audio</mat-option>
+              <mat-option value="text">Text</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <span class="option-hint">
+            @if (audioSimulationEnabled) {
+              Synthesizes the simulated user's turns to speech with a Gemini TTS
+              model.
+            } @else {
+              Sends the simulated user's turns as text.
+            }
+          </span>
+        </div>
+
+        @if (audioSimulationEnabled) {
+          <div class="audio-sim-fields">
+            <mat-form-field appearance="outline">
+              <mat-label>Voice</mat-label>
+              <mat-select formControlName="voiceName">
+                @for (voice of voices; track voice) {
+                  <mat-option [value]="voice">{{ voice }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Language code</mat-label>
+              <input matInput formControlName="languageCode" placeholder="en-US" />
+            </mat-form-field>
+          </div>
+        }
+      </form>
+    }
+
+    <!-- ---- Metrics ---- -->
     <form [formGroup]="evalForm" class="eval-form">
-      
-      <!-- Dynamic Metrics -->
       <div *ngIf="metricsInfo.length > 0">
         <div *ngFor="let metric of metricsInfo" class="metric-container">
           <div class="metric-header">
@@ -28,7 +92,7 @@
                 <span class="metric-description">{{ metric.description }}</span>
               </div>
             </mat-checkbox>
-            
+
             <div class="metric-slider-container inline-slider" [style.visibility]="evalForm.get(metric.metricName + '_selected')?.value ? 'visible' : 'hidden'">
               <div style="display: flex; flex-direction: column; align-items: flex-start;">
                 <span class="slider-label" style="margin-right: 0; font-size: 11px; color: var(--mat-sys-on-surface-variant);">Threshold</span>
@@ -46,15 +110,14 @@
         </div>
       </div>
 
-      <!-- Fallback if metricsInfo is empty -->
+      <!-- Fallback if metricsInfo is empty (backend metrics-info unavailable). -->
       <div *ngIf="metricsInfo.length === 0">
-        <!-- Hardcoded Tool Trajectory -->
         <div class="metric-container">
           <div class="metric-header">
             <mat-checkbox formControlName="tool_trajectory_avg_score_selected">
               <span class="metric-title" [matTooltip]="'tool_trajectory_avg_score'">{{ 'tool_trajectory_avg_score' | formatMetricName }}</span>
             </mat-checkbox>
-            
+
             <div class="metric-slider-container inline-slider" [style.visibility]="evalForm.get('tool_trajectory_avg_score_selected')?.value ? 'visible' : 'hidden'">
               <div style="display: flex; flex-direction: column; align-items: flex-start;">
                 <span class="slider-label" style="margin-right: 0; font-size: 11px; color: var(--mat-sys-on-surface-variant);">Threshold</span>
@@ -71,13 +134,12 @@
           </div>
         </div>
 
-        <!-- Hardcoded Response Match -->
         <div class="metric-container">
           <div class="metric-header">
             <mat-checkbox formControlName="response_match_score_selected">
               <span class="metric-title" [matTooltip]="'response_match_score'">{{ 'response_match_score' | formatMetricName }}</span>
             </mat-checkbox>
-            
+
             <div class="metric-slider-container inline-slider" [style.visibility]="evalForm.get('response_match_score_selected')?.value ? 'visible' : 'hidden'">
               <div style="display: flex; flex-direction: column; align-items: flex-start;">
                 <span class="slider-label" style="margin-right: 0; font-size: 11px; color: var(--mat-sys-on-surface-variant);">Threshold</span>
@@ -94,13 +156,14 @@
           </div>
         </div>
       </div>
-
     </form>
   </mat-dialog-content>
 
   <mat-dialog-actions align="end" class="dialog-actions">
     <button mat-button (click)="onReset()" class="reset-button">Reset to Default</button>
     <button mat-button (click)="onCancel()" class="cancel-button">Cancel</button>
-    <button mat-button (click)="onStart()" class="save-button">Start</button>
+    <button mat-flat-button color="primary" (click)="onStart()" class="save-button">
+      <mat-icon>play_arrow</mat-icon> Run
+    </button>
   </mat-dialog-actions>
 </div>

--- a/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.scss
+++ b/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.scss
@@ -1,9 +1,6 @@
-.dialog-container {
-  border-radius: 12px;
-  padding: 12px;
+.run-eval-config-dialog {
   width: 680px;
-  box-shadow: 0 8px 16px
-    var(--run-eval-config-dialog-container-box-shadow-color);
+  max-width: 90vw;
 }
 
 .metric-container {
@@ -64,6 +61,69 @@
   margin-left: 10px;
   min-width: 30px;
   text-align: right;
+}
+
+/* ---- Run mode selector (top of dialog) ---- */
+.run-mode-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--run-eval-config-dialog-border-color, #e0e0e0);
+}
+
+.run-mode-toggle {
+  width: 100%;
+}
+
+.run-mode-toggle .mat-button-toggle {
+  flex: 1;
+}
+
+/* ---- Live input modality + audio user simulation ---- */
+.run-options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--run-eval-config-dialog-border-color, #e0e0e0);
+}
+
+.run-option-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.option-hint {
+  font-size: 0.85em;
+  color: var(--run-eval-config-dialog-description-color, #666);
+  margin-left: 2px;
+}
+
+.modality-row {
+  gap: 6px;
+}
+
+.modality-field {
+  max-width: 220px;
+}
+
+/* Trim the outline field's default bottom padding so the hint sits close. */
+.modality-field ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+  display: none;
+}
+
+.audio-sim-fields {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.audio-sim-fields mat-form-field {
+  flex: 1;
 }
 
 h2[mat-dialog-title] {

--- a/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.spec.ts
+++ b/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.spec.ts
@@ -22,138 +22,193 @@ import {
   MatDialogModule,
   MatDialogRef,
 } from '@angular/material/dialog';
-import {MatRadioModule} from '@angular/material/radio';
 import {MatSliderModule} from '@angular/material/slider';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
-
 import {RunEvalConfigDialogComponent} from './run-eval-config-dialog.component';
 
-describe('RunEvalConfigDialogComponent', () => {
-  let component: RunEvalConfigDialogComponent;
-  let fixture: ComponentFixture<RunEvalConfigDialogComponent>;
-  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<RunEvalConfigDialogComponent>>;
+const METRICS_INFO = [
+  {
+    metricName: 'tool_trajectory_avg_score',
+    description: 'Tool trajectory score',
+    metricValueInfo: {
+      interval: {minValue: 0, maxValue: 1, openAtMin: false, openAtMax: false},
+    },
+  },
+  {
+    metricName: 'response_match_score',
+    description: 'Response match score',
+    metricValueInfo: {
+      interval: {minValue: 0, maxValue: 1, openAtMin: false, openAtMax: false},
+    },
+  },
+];
 
-  // Mock MatDialogRef
+async function createComponent(data: any):
+    Promise<{
+      fixture: ComponentFixture<RunEvalConfigDialogComponent>,
+      component: RunEvalConfigDialogComponent,
+      dialogRef: jasmine.SpyObj<MatDialogRef<RunEvalConfigDialogComponent>>,
+    }> {
   const mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  await TestBed.configureTestingModule({
     imports: [
-        ReactiveFormsModule,
-        MatDialogModule,
-        MatRadioModule,
-        MatSliderModule,
-        NoopAnimationsModule,
-        RunEvalConfigDialogComponent,
+      ReactiveFormsModule,
+      MatDialogModule,
+      MatSliderModule,
+      NoopAnimationsModule,
+      RunEvalConfigDialogComponent,
     ],
     providers: [
-        { provide: MatDialogRef, useValue: mockDialogRef },
-        {
-            provide: MAT_DIALOG_DATA,
-            useValue: {
-                evalMetrics: [
-                    {
-                        metricName: 'tool_trajectory_avg_score',
-                        threshold: 1,
-                    },
-                    {
-                        metricName: 'response_match_score',
-                        threshold: 0.7,
-                    },
-                ],
-            },
-        },
-        // Provide empty data for initial setup
+      {provide: MatDialogRef, useValue: mockDialogRef},
+      {provide: MAT_DIALOG_DATA, useValue: data},
     ],
-}).compileComponents();
-  });
+  }).compileComponents();
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RunEvalConfigDialogComponent);
-    component = fixture.componentInstance;
-    dialogRefSpy = TestBed.inject(MatDialogRef) as jasmine.SpyObj<
-      MatDialogRef<RunEvalConfigDialogComponent>
-    >;
-    fixture.detectChanges(); // Initialize the component and trigger change
-    // detection
-  });
+  const fixture = TestBed.createComponent(RunEvalConfigDialogComponent);
+  const component = fixture.componentInstance;
+  const dialogRef = TestBed.inject(MatDialogRef) as jasmine.SpyObj<
+      MatDialogRef<RunEvalConfigDialogComponent>>;
+  fixture.detectChanges();
+  return {fixture, component, dialogRef};
+}
 
-  it('should initialize form with default values', () => {
-    expect(
-      component.evalForm.get('tool_trajectory_avg_score_threshold')?.value
-    ).toBe(1);
-    expect(
-      component.evalForm.get('response_match_score_threshold')?.value
-    ).toBe(0.7);
-  });
-
-  it('should close dialog with null on cancel', () => {
-    component.onCancel();
-    expect(dialogRefSpy.close).toHaveBeenCalledWith(null);
-  });
-
-  it('should update threshold value when slider changes (simulated)', () => {
-    const toolTrajectoryAvgScoreSlider = component.evalForm.get(
-      'tool_trajectory_avg_score_threshold'
-    )!;
-    const responseMatchScoreSlider = component.evalForm.get(
-      'response_match_score_threshold'
-    )!;
-
-    toolTrajectoryAvgScoreSlider.setValue(0.4); // Simulate slider value change
-    responseMatchScoreSlider.setValue(0.5); // Simulate slider value change
-    fixture.detectChanges();
-
-    expect(toolTrajectoryAvgScoreSlider.value).toBe(0.4);
-    expect(responseMatchScoreSlider.value).toBe(0.5);
-    const thresholdValueDisplays =
-      fixture.nativeElement.querySelectorAll('.threshold-value');
-    expect(thresholdValueDisplays[0].textContent).toContain('0.4');
-    expect(thresholdValueDisplays[1].textContent).toContain('0.5');
-  });
-
+describe('RunEvalConfigDialogComponent', () => {
   describe('with metricsInfo', () => {
+    let component: RunEvalConfigDialogComponent;
+    let fixture: ComponentFixture<RunEvalConfigDialogComponent>;
+    let dialogRef: jasmine.SpyObj<MatDialogRef<RunEvalConfigDialogComponent>>;
+
     beforeEach(async () => {
-      TestBed.resetTestingModule();
-      await TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          MatDialogModule,
-          MatRadioModule,
-          MatSliderModule,
-          NoopAnimationsModule,
-          RunEvalConfigDialogComponent,
-        ],
-        providers: [
-          { provide: MatDialogRef, useValue: mockDialogRef },
-          {
-            provide: MAT_DIALOG_DATA,
-            useValue: {
-              evalMetrics: [],
-              metricsInfo: [
-                {
-                  metricName: 'custom_metric',
-                  description: 'Custom metric description',
-                  metricValueInfo: {
-                    interval: { minValue: 0, maxValue: 10, openAtMin: false, openAtMax: false }
-                  }
-                }
-              ]
-            },
-          },
-        ],
-      }).compileComponents();
+      ({fixture, component, dialogRef} = await createComponent({
+         evalMetrics: [
+           {metricName: 'tool_trajectory_avg_score', threshold: 1},
+           {metricName: 'response_match_score', threshold: 0.7},
+         ],
+         metricsInfo: METRICS_INFO,
+       }));
     });
 
-    it('should initialize form with dynamic controls', () => {
-      const fixture2 = TestBed.createComponent(RunEvalConfigDialogComponent);
-      const component2 = fixture2.componentInstance;
-      fixture2.detectChanges();
+    it('creates per-metric controls from metricsInfo', () => {
+      expect(component.evalForm.get('tool_trajectory_avg_score_selected'))
+          .toBeTruthy();
+      expect(component.evalForm.get('tool_trajectory_avg_score_threshold')?.value)
+          .toBe(1);
+      expect(component.evalForm.get('response_match_score_threshold')?.value)
+          .toBe(0.7);
+    });
 
-      expect(component2.evalForm.get('custom_metric_selected')).toBeTruthy();
-      expect(component2.evalForm.get('custom_metric_threshold')).toBeTruthy();
-      expect(component2.evalForm.get('custom_metric_threshold')?.value).toBe(10); // Default to max
+    it('closes with null on cancel', () => {
+      component.onCancel();
+      expect(dialogRef.close).toHaveBeenCalledWith(null);
+    });
+
+    it('emits selected metrics with useLive false and no simulator config',
+       () => {
+         component.evalForm.get('tool_trajectory_avg_score_selected')
+             ?.setValue(true);
+         component.evalForm.get('tool_trajectory_avg_score_threshold')
+             ?.setValue(0.9);
+         component.evalForm.get('response_match_score_selected')?.setValue(false);
+
+         component.onStart();
+
+         const arg = dialogRef.close.calls.mostRecent().args[0] as any;
+         expect(arg.useLive).toBeFalse();
+         expect(arg.userSimulatorConfig).toBeUndefined();
+         expect(arg.metrics).toEqual([
+           {metricName: 'tool_trajectory_avg_score', threshold: 0.9},
+         ]);
+       });
+
+    it('emits useLive true without a simulator config for the text modality',
+       () => {
+         component.runForm.get('runMode')?.setValue('live');
+         component.runForm.get('inputModality')?.setValue('text');
+
+         component.onStart();
+
+         const arg = dialogRef.close.calls.mostRecent().args[0] as any;
+         expect(arg.useLive).toBeTrue();
+         expect(arg.userSimulatorConfig).toBeUndefined();
+       });
+
+    it('emits an llm_audio user simulator config for the audio modality', () => {
+      component.runForm.get('runMode')?.setValue('live');
+      component.runForm.get('inputModality')?.setValue('audio');
+      component.runForm.get('voiceName')?.setValue('Puck');
+      component.runForm.get('languageCode')?.setValue('en-GB');
+
+      component.onStart();
+
+      const arg = dialogRef.close.calls.mostRecent().args[0] as any;
+      expect(arg.useLive).toBeTrue();
+      expect(arg.userSimulatorConfig).toEqual({
+        type: 'llm_audio',
+        audio_model: 'gemini-3.1-flash-tts-preview',
+        audio_model_configuration: {
+          response_modalities: ['AUDIO'],
+          speech_config: {
+            voice_config: {
+              prebuilt_voice_config: {voice_name: 'Puck'},
+            },
+            language_code: 'en-GB',
+          },
+        },
+      });
+    });
+
+    it('enables audio simulation only for live runs with the audio modality',
+       () => {
+         // Live on, but text modality selected.
+         component.runForm.get('runMode')?.setValue('live');
+         component.runForm.get('inputModality')?.setValue('text');
+         expect(component.audioSimulationEnabled).toBeFalse();
+
+         // Audio modality but standard (non-live) mode.
+         component.runForm.get('runMode')?.setValue('standard');
+         component.runForm.get('inputModality')?.setValue('audio');
+         expect(component.audioSimulationEnabled).toBeFalse();
+
+         // Live on + audio modality.
+         component.runForm.get('runMode')?.setValue('live');
+         expect(component.audioSimulationEnabled).toBeTrue();
+       });
+  });
+
+  describe('without metricsInfo (fallback)', () => {
+    let component: RunEvalConfigDialogComponent;
+    let dialogRef: jasmine.SpyObj<MatDialogRef<RunEvalConfigDialogComponent>>;
+
+    beforeEach(async () => {
+      ({component, dialogRef} = await createComponent({
+         evalMetrics: [
+           {metricName: 'tool_trajectory_avg_score', threshold: 1},
+           {metricName: 'response_match_score', threshold: 0.7},
+         ],
+         metricsInfo: [],
+       }));
+    });
+
+    it('adds hardcoded fallback metric controls', () => {
+      expect(component.evalForm.get('tool_trajectory_avg_score_threshold')?.value)
+          .toBe(1);
+      expect(component.evalForm.get('response_match_score_threshold')?.value)
+          .toBe(0.7);
+    });
+
+    it('emits fallback metrics that are selected', () => {
+      component.evalForm.get('tool_trajectory_avg_score_selected')
+          ?.setValue(true);
+      component.evalForm.get('response_match_score_selected')?.setValue(true);
+
+      component.onStart();
+
+      const arg = dialogRef.close.calls.mostRecent().args[0] as any;
+      expect(arg.metrics.map((m: any) => m.metricName)).toEqual([
+        'tool_trajectory_avg_score',
+        'response_match_score',
+      ]);
     });
   });
 });

--- a/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.ts
+++ b/src/app/components/eval-tab/run-eval-config-dialog/run-eval-config-dialog.component.ts
@@ -19,13 +19,19 @@ import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogTitle, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 
-import {EvalMetric, MetricsInfo, DEFAULT_EVAL_METRICS} from '../../../core/models/Eval';
+import {AUDIO_SIMULATOR_VOICES, DEFAULT_AUDIO_MODEL, EvalMetric, MetricsInfo, DEFAULT_EVAL_METRICS, UserSimulatorConfig} from '../../../core/models/Eval';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { MatSlider, MatSliderThumb } from '@angular/material/slider';
 import { MatButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { CommonModule } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FormatMetricNamePipe } from '../format-metric-name.pipe';
 
 /**
@@ -37,6 +43,30 @@ export interface EvalConfigData {
   evalMetrics: EvalMetric[];
   metricsInfo: MetricsInfo[];
 }
+
+/** Result emitted when the dialog is confirmed, consumed by runEval. */
+export interface RunEvalDialogResult {
+  metrics: EvalMetric[];
+  useLive: boolean;
+  // Present only when the audio user simulator is enabled for a live run.
+  userSimulatorConfig?: UserSimulatorConfig;
+}
+
+const DEFAULT_VOICE_NAME = 'Kore';
+const DEFAULT_LANGUAGE_CODE = 'en-US';
+
+/**
+ * Top-level evaluation run mode. `standard` is the default (non-live) run;
+ * `live` uses bidirectional streaming inference.
+ */
+export type EvalRunMode = 'standard'|'live';
+
+const DEFAULT_RUN_MODE: EvalRunMode = 'standard';
+
+export type LiveInputModality = 'audio'|'text';
+
+/** Default modality when live mode is enabled (audio is the common case). */
+const DEFAULT_INPUT_MODALITY: LiveInputModality = 'audio';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.Default,
@@ -56,6 +86,12 @@ export interface EvalConfigData {
         MatCheckbox,
         CommonModule,
         MatTooltip,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatSlideToggleModule,
+        MatButtonToggleModule,
+        MatIconModule,
         FormatMetricNamePipe,
     ],
 })
@@ -63,8 +99,13 @@ export class RunEvalConfigDialogComponent {
   // FormGroup to manage the dialog's form controls
   evalForm: FormGroup;
 
+  // Live run + optional audio user simulation controls.
+  runForm: FormGroup;
+
   evalMetrics: EvalMetric[] = [];
   metricsInfo: MetricsInfo[] = [];
+
+  readonly voices = AUDIO_SIMULATOR_VOICES;
 
   constructor(
       public dialogRef: MatDialogRef<RunEvalConfigDialogComponent>,
@@ -72,6 +113,13 @@ export class RunEvalConfigDialogComponent {
       @Inject(MAT_DIALOG_DATA) public data: EvalConfigData) {
     this.evalMetrics = this.data.evalMetrics || [];
     this.metricsInfo = this.data.metricsInfo || [];
+
+    this.runForm = this.fb.group({
+      runMode: [DEFAULT_RUN_MODE],
+      inputModality: [DEFAULT_INPUT_MODALITY],
+      voiceName: [DEFAULT_VOICE_NAME],
+      languageCode: [DEFAULT_LANGUAGE_CODE],
+    });
 
     // Initialize the form
     this.evalForm = this.fb.group({});
@@ -142,38 +190,62 @@ export class RunEvalConfigDialogComponent {
     }
   }
 
-  onStart(): void {
-    if (this.evalForm.valid) {
-      const resultMetrics: EvalMetric[] = [];
+  get isLive(): boolean {
+    return this.runForm.get('runMode')?.value === 'live';
+  }
 
-      if (this.metricsInfo.length > 0) {
-        this.metricsInfo.forEach(metric => {
-          const isSelected = this.evalForm.get(`${metric.metricName}_selected`)?.value;
-          if (isSelected) {
-            const threshold = this.evalForm.get(`${metric.metricName}_threshold`)?.value;
-            resultMetrics.push({
-              metricName: metric.metricName,
-              threshold: threshold
-            });
-          }
-        });
-      } else {
-        // Fallback if metricsInfo was empty
-        const defaultMetrics = ['tool_trajectory_avg_score', 'response_match_score'];
-        defaultMetrics.forEach(name => {
-          const isSelected = this.evalForm.get(`${name}_selected`)?.value;
-          if (isSelected) {
-            const threshold = this.evalForm.get(`${name}_threshold`)?.value;
-            resultMetrics.push({
-              metricName: name,
-              threshold: threshold
-            });
-          }
-        });
+  get audioSimulationEnabled(): boolean {
+    return this.isLive &&
+        this.runForm.get('inputModality')?.value === 'audio';
+  }
+
+  private collectMetrics(): EvalMetric[] {
+    const resultMetrics: EvalMetric[] = [];
+    const names = this.metricsInfo.length > 0 ?
+        this.metricsInfo.map((m) => m.metricName) :
+        ['tool_trajectory_avg_score', 'response_match_score'];
+    names.forEach((name) => {
+      if (this.evalForm.get(`${name}_selected`)?.value) {
+        const threshold = this.evalForm.get(`${name}_threshold`)?.value;
+        resultMetrics.push({metricName: name, threshold});
       }
+    });
+    return resultMetrics;
+  }
 
-      this.dialogRef.close(resultMetrics);
+  // Builds the `llm_audio` config from the audio form fields (Gemini TTS model
+  // + voice/language), or undefined when audio simulation is off.
+  private buildUserSimulatorConfig(): UserSimulatorConfig|undefined {
+    if (!this.audioSimulationEnabled) {
+      return undefined;
     }
+    const raw = this.runForm.getRawValue();
+    return {
+      type: 'llm_audio',
+      audio_model: DEFAULT_AUDIO_MODEL,
+      audio_model_configuration: {
+        response_modalities: ['AUDIO'],
+        speech_config: {
+          voice_config: {
+            prebuilt_voice_config: {
+              voice_name: raw.voiceName || DEFAULT_VOICE_NAME,
+            },
+          },
+          language_code: raw.languageCode || DEFAULT_LANGUAGE_CODE,
+        },
+      },
+    };
+  }
+
+  onStart(): void {
+    if (!this.evalForm.valid) {
+      return;
+    }
+    this.dialogRef.close({
+      metrics: this.collectMetrics(),
+      useLive: this.isLive,
+      userSimulatorConfig: this.buildUserSimulatorConfig(),
+    } as RunEvalDialogResult);
   }
 
   onCancel(): void {

--- a/src/app/core/models/Eval.ts
+++ b/src/app/core/models/Eval.ts
@@ -72,7 +72,7 @@ export declare interface IntermediateData {
 
 export declare interface EvalCase {
   evalId: string;
-  conversation: Invocation[];
+  conversation?: Invocation[];
   events?: any[];
   sessionInput: any;
   creationTimestamp: number;
@@ -86,6 +86,13 @@ export declare interface EvalSet {
   creationTimestamp: number;
 }
 
+/** Eval verdict values returned by the backend (`evalStatus`/`finalEvalStatus`). */
+export enum EvalStatus {
+  PASSED = 1,
+  FAILED = 2,
+  NOT_EVALUATED = 3,
+}
+
 export declare interface EvaluationResult {
   setId: string;
   evalId: string;
@@ -95,4 +102,45 @@ export declare interface EvaluationResult {
   evalMetricResultPerInvocation?: any[];
   sessionId: string;
   sessionDetails: any;
+  // The user id the eval ran under. Needed to fetch the run's session.
+  userId?: string;
 }
+
+// Audio user-simulator config, mirroring the adk-python `UserSimulatorConfig`
+// union. Only the `llm_audio` subset (the field the UI sends) is modelled;
+// text-generation fields are defaulted by the backend.
+
+/** Voice/language selection for a synthesized user turn. */
+export declare interface SpeechConfig {
+  voice_config: {
+    prebuilt_voice_config: {
+      voice_name: string;
+    };
+  };
+  language_code?: string;
+}
+
+/** Sent as `user_simulator_config` to synthesize the simulated user's turns. */
+export declare interface LlmAudioUserSimulatorConfig {
+  type: 'llm_audio';
+  // A Gemini TTS model name, or 'cloud_tts' for Google Cloud Text-to-Speech.
+  audio_model?: string;
+  audio_model_configuration?: {
+    response_modalities?: string[];
+    speech_config: SpeechConfig;
+  };
+}
+
+export type UserSimulatorConfig = LlmAudioUserSimulatorConfig;
+
+/** The Gemini TTS model the audio user simulator uses by default. */
+export const DEFAULT_AUDIO_MODEL = 'gemini-3.1-flash-tts-preview';
+
+/** Prebuilt Gemini TTS voice names offered by the run dialog. */
+export const AUDIO_SIMULATOR_VOICES: string[] = [
+  'Kore',
+  'Puck',
+  'Charon',
+  'Aoede',
+  'Fenrir',
+];

--- a/src/app/core/models/UiEvent.ts
+++ b/src/app/core/models/UiEvent.ts
@@ -25,7 +25,9 @@ export class UiEvent {
   isLoading?: boolean;
   isEditing?: boolean;
   evalStatus?: number;
-  failedMetric?: boolean;
+  // The name of the metric that failed for this event (e.g.
+  // 'response_match_score'), or empty when the event passed.
+  failedMetric?: string;
   attachments?: { file: File; url: string }[];
   renderedContent?: any;
   a2uiData?: any;

--- a/src/app/core/services/eval.service.spec.ts
+++ b/src/app/core/services/eval.service.spec.ts
@@ -41,7 +41,8 @@ const EVAL_CASE_PATH = `${EVAL_CASES_PATH}/${EVAL_CASE_ID}`;
 const EVAL_RESULTS_PATH = `/dev/apps/${APP_NAME}/eval_results`;
 const EVAL_RESULT_PATH = `${EVAL_RESULTS_PATH}/${EVAL_RESULT_ID}`;
 const ADD_SESSION_PATH = `${EVAL_SET_PATH}/add_session`;
-const RUN_EVAL_PATH = `${EVAL_SET_PATH}/run_eval`;
+const RUN_EVAL_PATH =
+    `/dev/apps/${APP_NAME}/eval-sets/${EVAL_SET_ID}/run`;
 
 describe('EvalService', () => {
   let service: EvalService;
@@ -85,6 +86,25 @@ describe('EvalService', () => {
       req.flush(null);
       const result = await resultP;
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getEvalSet', () => {
+    it('should call GET /apps/{appName}/eval-sets/{evalSetId}', () => {
+      service.getEvalSet(APP_NAME, EVAL_SET_ID).subscribe();
+      const req = httpTestingController.expectOne(
+          API_SERVER_BASE_URL + `/dev/apps/${APP_NAME}/eval-sets/${EVAL_SET_ID}`,
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush({});
+    });
+
+    it('should return empty observable if no api domain', async () => {
+      service.apiServerDomain = '';
+      const result = service.getEvalSet(APP_NAME, EVAL_SET_ID);
+      httpTestingController.expectNone(
+          `/dev/apps/${APP_NAME}/eval-sets/${EVAL_SET_ID}`);
+      expect(result).toBeTruthy();
     });
   });
 
@@ -160,19 +180,61 @@ describe('EvalService', () => {
   });
 
   describe('runEval', () => {
-    it('should call POST /apps/{appName}/eval_sets/{evalSetId}/run_eval with correct body',
+    it('should call POST /dev/apps/{appName}/eval-sets/{evalSetId}/run with correct body',
        () => {
-         service.runEval(APP_NAME, EVAL_SET_ID, [EVAL_ID], [{}]).subscribe();
+         service.runEval(APP_NAME, EVAL_SET_ID, [EVAL_ID], [{}] as any)
+             .subscribe();
          const req = httpTestingController.expectOne(
              API_SERVER_BASE_URL + RUN_EVAL_PATH,
          );
          expect(req.request.method).toEqual('POST');
-         expect(req.request.body).toEqual({
-           evalIds: [EVAL_ID],
-           evalMetrics: [{}],
-         });
-         req.flush({});
-       });
+          expect(req.request.body).toEqual({
+            eval_case_ids: [EVAL_ID],
+            eval_metrics: [{}],
+          });
+          expect(req.request.body.live_model_config).toBeUndefined();
+          req.flush({});
+        });
+
+    it('sends live_model_config for live runs', () => {
+      service
+          .runEval(APP_NAME, EVAL_SET_ID, [EVAL_ID], [{}] as any, true)
+          .subscribe();
+      const req = httpTestingController.expectOne(
+          API_SERVER_BASE_URL + RUN_EVAL_PATH,
+      );
+      expect(req.request.body.live_model_config).toEqual({});
+      expect(req.request.body.use_live).toBeUndefined();
+      expect(req.request.body.user_simulator_config).toBeUndefined();
+      req.flush({});
+    });
+
+    it('sends user_simulator_config when supplied', () => {
+      const userSimulatorConfig = {
+        type: 'llm_audio' as const,
+        audio_model: 'cloud_tts',
+        audio_model_configuration: {
+          speech_config: {
+            voice_config: {
+              prebuilt_voice_config: {voice_name: 'en-US-Studio-O'},
+            },
+            language_code: 'en-US',
+          },
+        },
+      };
+      service
+          .runEval(
+              APP_NAME, EVAL_SET_ID, [EVAL_ID], [{}] as any, true,
+              userSimulatorConfig)
+          .subscribe();
+      const req = httpTestingController.expectOne(
+          API_SERVER_BASE_URL + RUN_EVAL_PATH,
+      );
+      expect(req.request.body.live_model_config).toEqual({});
+      expect(req.request.body.user_simulator_config)
+          .toEqual(userSimulatorConfig);
+      req.flush({});
+    });
   });
 
   describe('listEvalResults', () => {

--- a/src/app/core/services/eval.service.ts
+++ b/src/app/core/services/eval.service.ts
@@ -21,7 +21,7 @@ import {Observable, of} from 'rxjs';
 import {tap} from 'rxjs/operators';
 
 import {URLUtil} from '../../../utils/url-util';
-import {EvalCase} from '../models/Eval';
+import {EvalCase, EvalMetric, UserSimulatorConfig} from '../models/Eval';
 import {EvalService as EvalServiceInterface} from './interfaces/eval';
 
 @Injectable({
@@ -80,7 +80,7 @@ export class EvalService implements EvalServiceInterface {
   getEvalSet(appName: string, evalSetId: string) {
     if (this.apiServerDomain != undefined) {
       const url =
-        this.apiServerDomain + `/dev/apps/${appName}/eval_sets/${evalSetId}`;
+        this.apiServerDomain + `/dev/apps/${appName}/eval-sets/${evalSetId}`;
       return this.http.get<any>(url, {});
     }
     return new Observable<any>();
@@ -112,18 +112,30 @@ export class EvalService implements EvalServiceInterface {
     });
   }
 
+  // Live mode is signalled to the backend by the presence of
+  // `live_model_config`, not a boolean; an empty object uses its default
+  // timeout. `userSimulatorConfig` (e.g. `llm_audio`) synthesizes user turns.
   runEval(
     appName: string,
     evalSetId: string,
-    evalIds: string[],
-    evalMetrics: any[],
+    evalCaseIds: string[],
+    evalMetrics: EvalMetric[],
+    useLive: boolean = false,
+    userSimulatorConfig?: UserSimulatorConfig,
   ) {
     const url =
-      this.apiServerDomain + `/dev/apps/${appName}/eval_sets/${evalSetId}/run_eval`;
-    return this.http.post<any>(url, {
-      evalIds: evalIds,
-      evalMetrics: evalMetrics,
-    });
+      this.apiServerDomain + `/dev/apps/${appName}/eval-sets/${evalSetId}/run`;
+    const body: any = {
+      eval_case_ids: evalCaseIds,
+      eval_metrics: evalMetrics,
+    };
+    if (useLive) {
+      body.live_model_config = {};
+    }
+    if (userSimulatorConfig) {
+      body.user_simulator_config = userSimulatorConfig;
+    }
+    return this.http.post<any>(url, body);
   }
 
   listEvalResults(appName: string) {
@@ -174,7 +186,7 @@ export class EvalService implements EvalServiceInterface {
   }
 
   deleteEvalSet(appName: string, evalSetId: string) {
-    const url = this.apiServerDomain + `/dev/apps/${appName}/eval_sets/${evalSetId}`;
+    const url = this.apiServerDomain + `/dev/apps/${appName}/eval-sets/${evalSetId}`;
     return this.http.delete<any>(url, {});
   }
 }

--- a/src/app/core/services/interfaces/eval.ts
+++ b/src/app/core/services/interfaces/eval.ts
@@ -17,7 +17,7 @@
 
 import {InjectionToken, WritableSignal} from '@angular/core';
 import {Observable} from 'rxjs';
-import {EvalCase} from '../../models/Eval';
+import {EvalCase, EvalMetric, UserSimulatorConfig} from '../../models/Eval';
 
 export const EVAL_SERVICE = new InjectionToken<EvalService>('EvalService');
 
@@ -41,8 +41,10 @@ export declare abstract class EvalService {
   abstract runEval(
     appName: string,
     evalSetId: string,
-    evalIds: string[],
-    evalMetrics: any[],
+    evalCaseIds: string[],
+    evalMetrics: EvalMetric[],
+    useLive?: boolean,
+    userSimulatorConfig?: UserSimulatorConfig,
   ): Observable<any>;
   abstract listEvalResults(appName: string): Observable<any>;
   abstract getEvalResult(appName: string, evalResultId: string): Observable<any>;

--- a/src/app/core/services/testing/mock-eval.service.ts
+++ b/src/app/core/services/testing/mock-eval.service.ts
@@ -52,4 +52,6 @@ export class MockEvalService implements Partial<EvalService> {
   deleteEvalCaseResponse = new ReplaySubject<any>(1);
   deleteEvalCase = jasmine.createSpy('deleteEvalCase')
                        .and.returnValue(this.deleteEvalCaseResponse);
+  getMetricsInfo = jasmine.createSpy('getMetricsInfo')
+                       .and.returnValue(of({metricsInfo: []}));
 }

--- a/src/app/core/utils/audio.spec.ts
+++ b/src/app/core/utils/audio.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {base64ToArrayBuffer, pcmChunksToWavBase64} from './audio';
+
+/** Decodes base64 -> Uint8Array for assertions. */
+function bytes(base64: string): Uint8Array {
+  return new Uint8Array(base64ToArrayBuffer(base64));
+}
+
+/** Reads an ASCII tag from a byte array at an offset. */
+function tag(arr: Uint8Array, offset: number, length: number): string {
+  return String.fromCharCode(...arr.subarray(offset, offset + length));
+}
+
+describe('audio util - pcmChunksToWavBase64', () => {
+  const chunk = btoa('\x01\x02\x03\x04');  // 4 bytes = 2 samples
+
+  it('returns empty string when there are no chunks', () => {
+    expect(pcmChunksToWavBase64([])).toBe('');
+    expect(pcmChunksToWavBase64([''])).toBe('');
+  });
+
+  it('produces a valid RIFF/WAVE header', () => {
+    const wav = bytes(pcmChunksToWavBase64([chunk]));
+    expect(tag(wav, 0, 4)).toBe('RIFF');
+    expect(tag(wav, 8, 4)).toBe('WAVE');
+    expect(tag(wav, 12, 4)).toBe('fmt ');
+    expect(tag(wav, 36, 4)).toBe('data');
+  });
+
+  it('has correct total length (44 byte header + concatenated PCM)', () => {
+    // Two 4-byte chunks -> 8 bytes of PCM + 44 header.
+    const wav = bytes(pcmChunksToWavBase64([chunk, chunk]));
+    expect(wav.byteLength).toBe(44 + 8);
+
+    const view = new DataView(wav.buffer);
+    // data chunk size (offset 40) == PCM byte length.
+    expect(view.getUint32(40, true)).toBe(8);
+    // RIFF chunk size (offset 4) == 36 + PCM byte length.
+    expect(view.getUint32(4, true)).toBe(36 + 8);
+  });
+
+  it('encodes the default 24kHz / mono / 16-bit format', () => {
+    const wav = bytes(pcmChunksToWavBase64([chunk]));
+    const view = new DataView(wav.buffer);
+    expect(view.getUint16(20, true)).toBe(1);      // PCM format
+    expect(view.getUint16(22, true)).toBe(1);      // mono
+    expect(view.getUint32(24, true)).toBe(24000);  // sample rate
+    expect(view.getUint16(34, true)).toBe(16);     // bits per sample
+  });
+});

--- a/src/app/core/utils/audio.ts
+++ b/src/app/core/utils/audio.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Default sample rate (Hz) for live PCM audio produced by the model. */
+export const DEFAULT_PCM_SAMPLE_RATE = 24000;
+
+/**
+ * Decodes a (possibly url-safe / data-uri-prefixed) base64 string into an
+ * ArrayBuffer.
+ */
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  let cleaned = base64.replace(/\s/g, '');
+  const commaIndex = cleaned.indexOf(',');
+  if (commaIndex !== -1) {
+    cleaned = cleaned.substring(commaIndex + 1);
+  }
+  cleaned = cleaned.replace(/-/g, '+').replace(/_/g, '/');
+  while (cleaned.length % 4 !== 0) {
+    cleaned += '=';
+  }
+  const binaryString = window.atob(cleaned);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/** Encodes an ArrayBuffer into a (standard) base64 string. */
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+        null, bytes.subarray(i, i + chunkSize) as unknown as number[]);
+  }
+  return window.btoa(binary);
+}
+
+/** Writes an ASCII string into a DataView at the given byte offset. */
+function writeString(view: DataView, offset: number, str: string): void {
+  for (let i = 0; i < str.length; i++) {
+    view.setUint8(offset + i, str.charCodeAt(i));
+  }
+}
+
+/**
+ * Builds WAV (RIFF) bytes wrapping raw 16-bit little-endian PCM audio, so a
+ * browser `<audio>` element can play it. Live audio arrives as headerless PCM,
+ * which is otherwise unplayable. Returns the full WAV (header + PCM) buffer.
+ */
+export function pcmToWavArrayBuffer(
+    pcmBuffer: ArrayBuffer, sampleRate: number = DEFAULT_PCM_SAMPLE_RATE,
+    numChannels: number = 1): ArrayBuffer {
+  const out = new Uint8Array(44 + pcmBuffer.byteLength);
+  const view = new DataView(out.buffer);
+
+  writeString(view, 0, 'RIFF');
+  view.setUint32(4, 36 + pcmBuffer.byteLength, true);
+  writeString(view, 8, 'WAVE');
+  writeString(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);  // PCM format
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * numChannels * 2, true);
+  view.setUint16(32, numChannels * 2, true);
+  view.setUint16(34, 16, true);  // 16 bits per sample
+  writeString(view, 36, 'data');
+  view.setUint32(40, pcmBuffer.byteLength, true);
+
+  out.set(new Uint8Array(pcmBuffer), 44);
+  return out.buffer;
+}
+
+/**
+ * Wraps raw 16-bit little-endian PCM audio in a WAV Blob (for artifact-style
+ * playback paths that read from a Blob URL / FileReader).
+ */
+export function pcmToWavBlob(
+    pcmBuffer: ArrayBuffer, sampleRate: number = DEFAULT_PCM_SAMPLE_RATE,
+    numChannels: number = 1): Blob {
+  return new Blob(
+      [pcmToWavArrayBuffer(pcmBuffer, sampleRate, numChannels)],
+      {type: 'audio/wav'});
+}
+
+/**
+ * Concatenates one or more base64-encoded raw PCM chunks (16-bit
+ * little-endian) into a single WAV clip and returns its base64-encoded bytes
+ * (no data-uri prefix).
+ *
+ * Live model turns are streamed as many small PCM chunks; folding them into one
+ * WAV yields a single playable clip per turn instead of dozens of unplayable
+ * fragments. Returns an empty string when there is no audio.
+ */
+export function pcmChunksToWavBase64(
+    base64Chunks: string[], sampleRate: number = DEFAULT_PCM_SAMPLE_RATE,
+    numChannels: number = 1): string {
+  if (!base64Chunks || base64Chunks.length === 0) {
+    return '';
+  }
+
+  const buffers = base64Chunks.filter((chunk) => !!chunk)
+                      .map((chunk) => base64ToArrayBuffer(chunk));
+  const totalLength = buffers.reduce((sum, b) => sum + b.byteLength, 0);
+  if (totalLength === 0) {
+    return '';
+  }
+
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const buffer of buffers) {
+    merged.set(new Uint8Array(buffer), offset);
+    offset += buffer.byteLength;
+  }
+
+  // 16-bit samples must be 2-byte aligned.
+  const alignedLength = merged.byteLength - (merged.byteLength % 2);
+  const pcmBuffer = merged.buffer.slice(0, alignedLength);
+
+  return arrayBufferToBase64(
+      pcmToWavArrayBuffer(pcmBuffer, sampleRate, numChannels));
+}


### PR DESCRIPTION
## Summary

Adds live (bidi streaming) evaluation support to the eval UI, including an optional simulated audio user. The run dialog now leads with a `Standard | Live` mode selector; live runs can drive the agent with synthesized speech or plain text. Live results render as a clean per-turn conversation with playable audio and carry the same per-turn PASS/FAIL annotations that standard runs show.

- **Run dialog:** Live runs expose an *Input modality* dropdown (Audio by default, Text) plus voice and language-code fields for the simulated audio user.
- **Running live evals:** `runEval` posts to the V2 `eval-sets/{id}/run` endpoint, signaling live mode via the presence of `live_model_config` and passing `user_simulator_config` (`llm_audio`, Gemini TTS) to synthesize the user's turns.
- **Live result rendering:** a live run's raw session (audio chunks, partial transcriptions, turn-complete markers) is rebuilt into one bubble per turn, folding the streamed PCM for each response into a single playable WAV clip. PCM→WAV helpers are extracted into `core/utils/audio.ts` and reused by the existing artifact playback path.
- **Consistency & polish:** live result bubbles show per-turn PASS/FAIL plus failing-metric detail just like non-live runs; eval sessions load under the user id the eval actually ran as, the run spinner always clears on empty/error paths, and single-case runs open their result directly.