### PR TITLE
fix(artifact-tab): decode text artifacts as UTF-8

### DIFF
--- a/src/app/components/artifact-tab/artifact-tab.component.spec.ts
+++ b/src/app/components/artifact-tab/artifact-tab.component.spec.ts
@@ -51,4 +51,27 @@ describe('ArtifactTabComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('getTextContent', () => {
+    const toDataUrl = (text: string) => {
+      const base64 = btoa(
+        String.fromCharCode(...new TextEncoder().encode(text)),
+      );
+      return `data:text/plain;base64,${base64}`;
+    };
+
+    it('should decode multibyte UTF-8 content without garbling it', () => {
+      const text = 'こんにちは 🌙 مرحبا';
+      expect(component['getTextContent'](toDataUrl(text))).toBe(text);
+    });
+
+    it('should still decode ASCII content', () => {
+      const text = 'Hello, world!';
+      expect(component['getTextContent'](toDataUrl(text))).toBe(text);
+    });
+
+    it('should return an empty string for an empty data URL', () => {
+      expect(component['getTextContent']('')).toBe('');
+    });
+  });
 });

--- a/src/app/components/artifact-tab/artifact-tab.component.ts
+++ b/src/app/components/artifact-tab/artifact-tab.component.ts
@@ -158,7 +158,8 @@ export class ArtifactTabComponent implements OnChanges {
     if (commaIndex === -1) return '';
     const base64 = dataUrl.substring(commaIndex + 1);
     try {
-      return atob(base64);
+      const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+      return new TextDecoder('utf-8').decode(bytes);
     } catch (e) {
       return 'Failed to decode text content';
     }


### PR DESCRIPTION
## Summary

Fixes #452.

Text artifacts containing non-ASCII characters (Japanese, Arabic, emoji, …) rendered as mojibake in the **Artifacts** tab preview — e.g. `こんにちは` showed as `ã?"ã‚"ã?«ã?¡ã?¯`.

## Root cause

`getTextContent()` in `artifact-tab.component.ts` decoded the base64 payload with a bare `atob()`. `atob()` returns a "binary string" where each character is a single byte, so multibyte UTF-8 sequences are misinterpreted as Latin-1 (ISO-8859-1).

## Fix

Decode the base64 into raw bytes and run them through `TextDecoder('utf-8')`:

```ts
const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
return new TextDecoder('utf-8').decode(bytes);
```

This is the correct inverse of the UTF-8-aware encode path. I used `TextDecoder` rather than the `decodeURIComponent(escape(...))` idiom suggested in the issue, since `escape`/`unescape` are deprecated.

## Testing

Added regression tests to `artifact-tab.component.spec.ts` covering multibyte (`こんにちは 🌙 مرحبا`), ASCII, and empty-input cases. All component tests pass:

```
Chrome Headless: Executed 4 of 4 SUCCESS
```