### PR TITLE
Revert tree to 1be02eb to restore a building state

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm run serve --backend=http://localhost:8000
 In another terminal run:
 
 ```bash
-adk web --allow_origins=http://localhost:4200 --host=0.0.0.0
+adk api_server --allow_origins=http://localhost:4200 --host=0.0.0.0
 ```
 
 If you see `adk command not found`, then be sure to install `google-adk` (or remember to activate your virtual environment if you are using one)
@@ -115,3 +115,4 @@ This feature is subject to the "Pre-GA Offerings Terms" in the General Service T
 ---
 
 *Happy Agent Building!*
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@codemirror/lint": "^6.8.5",
         "@viz-js/viz": "^3.12.0",
         "codemirror": "^6.0.2",
+        "mermaid": "^11.14.0",
         "ngx-markdown": "^21.0.1",
         "ngx-vflow": "^1.16.4",
         "rxjs": "~7.8.0",
@@ -899,7 +900,6 @@
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
       "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "package-manager-detector": "^1.3.0",
         "tinyexec": "^1.0.1"
@@ -2551,52 +2551,44 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
-      "license": "Apache-2.0",
-      "optional": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-      "license": "Apache-2.0",
-      "optional": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.1",
@@ -3269,15 +3261,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@iconify/utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
       "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
@@ -4385,11 +4375,10 @@
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "langium": "^4.0.0"
       }
@@ -6486,7 +6475,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
       "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-array": "*",
         "@types/d3-axis": "*",
@@ -6524,15 +6512,13 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-axis": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
       "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -6542,7 +6528,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
       "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -6551,8 +6536,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
       "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
@@ -6565,7 +6549,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
       "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-array": "*",
         "@types/geojson": "*"
@@ -6575,15 +6558,13 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-dispatch": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
       "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",
@@ -6598,22 +6579,19 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
       "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-fetch": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
       "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-dsv": "*"
       }
@@ -6622,22 +6600,19 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
       "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
       "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-geo": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
       "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -6646,8 +6621,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
       "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
@@ -6662,36 +6636,31 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-polygon": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
       "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-quadtree": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
       "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-random": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
       "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
       "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -6700,8 +6669,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
@@ -6714,7 +6682,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
       "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-path": "*"
       }
@@ -6723,29 +6690,25 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-time-format": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
       "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
       "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/d3-selection": "*"
       }
@@ -6818,8 +6781,7 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -6977,7 +6939,6 @@
       "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
       "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
       "license": "MIT",
-      "optional": true,
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
@@ -7987,31 +7948,31 @@
       "license": "MIT"
     },
     "node_modules/chevrotain": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.1.2",
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/regexp-to-ast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "@chevrotain/utils": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.18.1"
       },
       "peerDependencies": {
-        "chevrotain": "^11.0.0"
+        "chevrotain": "^12.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -8270,7 +8231,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -8345,8 +8305,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -8575,7 +8534,6 @@
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
       "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "layout-base": "^1.0.0"
       }
@@ -8719,7 +8677,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8729,7 +8686,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
       "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cose-base": "^1.0.0"
       },
@@ -8742,7 +8698,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
       "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cose-base": "^2.2.0"
       },
@@ -8755,7 +8710,6 @@
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
       "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "layout-base": "^2.0.0"
       }
@@ -8764,15 +8718,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
       "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -8814,7 +8766,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
       "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -8827,7 +8778,6 @@
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
       "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -8837,7 +8787,6 @@
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
       "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -8854,7 +8803,6 @@
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
       "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -8876,7 +8824,6 @@
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
       "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-array": "^3.2.0"
       },
@@ -8889,7 +8836,6 @@
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
       "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delaunator": "5"
       },
@@ -8924,7 +8870,6 @@
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
       "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -8950,7 +8895,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 10"
       }
@@ -8960,7 +8904,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8982,7 +8925,6 @@
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
       "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -8995,7 +8937,6 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
       "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -9010,7 +8951,6 @@
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9020,7 +8960,6 @@
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -9033,7 +8972,6 @@
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
       "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9055,7 +8993,6 @@
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9065,7 +9002,6 @@
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9075,7 +9011,6 @@
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9085,7 +9020,6 @@
       "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
       "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -9095,7 +9029,6 @@
       "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
       "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "d3-array": "1 - 2",
         "d3-shape": "^1.2.0"
@@ -9106,7 +9039,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "internmap": "^1.0.0"
       }
@@ -9115,15 +9047,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey/node_modules/d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -9132,15 +9062,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -9157,7 +9085,6 @@
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -9180,7 +9107,6 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
       "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-path": "^3.1.0"
       },
@@ -9193,7 +9119,6 @@
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
       "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -9206,7 +9131,6 @@
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
       "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -9263,7 +9187,6 @@
       "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
       "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "d3": "^7.9.0",
         "lodash-es": "^4.17.21"
@@ -9283,8 +9206,7 @@
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -9352,7 +9274,6 @@
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
@@ -9500,7 +9421,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
       "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -10472,8 +10392,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -10948,7 +10867,6 @@
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -12048,7 +11966,6 @@
         "https://github.com/sponsors/katex"
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -12059,8 +11976,7 @@
     "node_modules/khroma": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
-      "optional": true
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -12073,14 +11989,14 @@
       }
     },
     "node_modules/langium": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "chevrotain": "~11.1.1",
-        "chevrotain-allstar": "~0.3.1",
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
         "vscode-uri": "~3.1.0"
@@ -12105,8 +12021,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/less": {
       "version": "4.4.2",
@@ -12422,9 +12337,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -12730,15 +12645,14 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.0.1",
+        "@mermaid-js/parser": "^1.1.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -12764,7 +12678,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
       "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
-      "optional": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -13064,7 +12977,6 @@
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
       "integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "pathe": "^2.0.3",
@@ -13685,8 +13597,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/pacote": {
       "version": "21.3.1",
@@ -13848,8 +13759,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -13930,8 +13840,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13992,7 +13901,6 @@
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
@@ -14021,15 +13929,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
       "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/points-on-path": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
       "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "path-data-parser": "0.1.0",
         "points-on-curve": "0.2.0"
@@ -14652,8 +14558,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "license": "Unlicense",
-      "optional": true
+      "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.4",
@@ -14737,7 +14642,6 @@
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
       "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "hachure-fill": "^0.5.2",
         "path-data-parser": "^0.1.0",
@@ -14779,8 +14683,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -14834,7 +14737,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/safevalues": {
@@ -15805,8 +15707,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -15998,7 +15899,6 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
       "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -16085,7 +15985,6 @@
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6.10"
       }
@@ -16204,8 +16103,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.22.0",
@@ -16371,7 +16269,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
@@ -16538,7 +16435,6 @@
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
       "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -16548,7 +16444,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
       "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "vscode-languageserver-protocol": "3.17.5"
       },
@@ -16561,7 +16456,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
         "vscode-languageserver-types": "3.17.5"
@@ -16571,22 +16465,19 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@codemirror/lint": "^6.8.5",
     "@viz-js/viz": "^3.12.0",
     "codemirror": "^6.0.2",
+    "mermaid": "^11.14.0",
     "ngx-markdown": "^21.0.1",
     "ngx-vflow": "^1.16.4",
     "rxjs": "~7.8.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -38,6 +38,7 @@ import {GRAPH_SERVICE} from './core/services/interfaces/graph';
 import {LOCAL_FILE_SERVICE} from './core/services/interfaces/localfile';
 import {SAFE_VALUES_SERVICE} from './core/services/interfaces/safevalues';
 import {STRING_TO_COLOR_SERVICE} from './core/services/interfaces/string-to-color';
+import {THEME_SERVICE} from './core/services/interfaces/theme';
 import {LOCATION_SERVICE} from './core/services/location.service';
 import {SESSION_SERVICE} from './core/services/interfaces/session';
 import {STREAM_CHAT_SERVICE} from './core/services/interfaces/stream-chat';
@@ -55,6 +56,7 @@ import {MockSafeValuesService} from './core/services/testing/mock-safevalues.ser
 import {MockSessionService} from './core/services/testing/mock-session.service';
 import {MockStreamChatService} from './core/services/testing/mock-stream-chat.service';
 import {MockStringToColorService} from './core/services/testing/mock-string-to-color.service';
+import {MockThemeService} from './core/services/testing/mock-theme.service';
 import {MockTraceService} from './core/services/testing/mock-trace.service';
 import {MockUiStateService} from './core/services/testing/mock-ui-state.service';
 import {MockVideoService} from './core/services/testing/mock-video.service';
@@ -197,6 +199,10 @@ describe('AppComponent', () => {
             {
               provide: AGENT_BUILDER_SERVICE,
               useValue: mockAgentBuilderService,
+            },
+            {
+              provide: THEME_SERVICE,
+              useClass: MockThemeService,
             },
             {
               provide: TelemetryService,

--- a/src/app/components/artifact-tab/artifact-tab.component.ts
+++ b/src/app/components/artifact-tab/artifact-tab.component.ts
@@ -34,8 +34,13 @@ const DEFAULT_ARTIFACT_NAME = 'default_artifact_name';
 /**
  * The supported media types for artifacts.
  */
-import { MediaType } from '../../core/models/types';
-export { MediaType };
+export enum MediaType {
+  IMAGE = 'image',
+  AUDIO = 'audio',
+  VIDEO = 'video',
+  TEXT = 'text',  // for text/html
+  UNSPECIFIED = 'unspecified',
+}
 
 /*
  * Returns the media type from the mime type.

--- a/src/app/components/builder-tabs/builder-tabs.component.spec.ts
+++ b/src/app/components/builder-tabs/builder-tabs.component.spec.ts
@@ -27,7 +27,7 @@ import {THEME_SERVICE} from '../../core/services/interfaces/theme';
 import {MockFeatureFlagService} from '../../core/services/testing/mock-feature-flag.service';
 import {MockThemeService} from '../../core/services/testing/mock-theme.service';
 import {MatDialog} from '@angular/material/dialog';
-import {MatSnackBar} from '@angular/material/snack-bar';
+import { SnackbarService } from '../../core/services/snackbar.service';
 import {Router} from '@angular/router';
 // 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
 import {initTestBed} from '../../testing/utils';
@@ -44,7 +44,7 @@ describe('BuilderTabsComponent - Callback Support', () => {
     ]);
     const mockFeatureFlagService = new MockFeatureFlagService();
     const mockDialog = jasmine.createSpyObj('MatDialog', ['open']);
-    const mockSnackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+    const mockSnackBar = jasmine.createSpyObj('SnackbarService', ['open']);
     const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
 
     initTestBed();  // required for 1p compat
@@ -55,7 +55,7 @@ describe('BuilderTabsComponent - Callback Support', () => {
         {provide: AGENT_SERVICE, useValue: agentServiceSpy},
         {provide: FEATURE_FLAG_SERVICE, useValue: mockFeatureFlagService},
         {provide: MatDialog, useValue: mockDialog},
-        {provide: MatSnackBar, useValue: mockSnackBar},
+        {provide: SnackbarService, useValue: mockSnackBar},
         {provide: Router, useValue: mockRouter},
         provideNoopAnimations(),
         {provide: THEME_SERVICE, useClass: MockThemeService},

--- a/src/app/components/chat-panel/chat-panel.component.spec.ts
+++ b/src/app/components/chat-panel/chat-panel.component.spec.ts
@@ -22,39 +22,32 @@ import {MatDialogModule} from '@angular/material/dialog';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 // 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {of} from 'rxjs';
+import {of, ReplaySubject} from 'rxjs';
+import {ARTIFACT_SERVICE} from '../../core/services/interfaces/artifact';
+import {MockArtifactService} from '../../core/services/testing/mock-artifact.service';
 
 import {UiEvent} from '../../core/models/UiEvent';
+import {isComputerUseResponse} from '../../core/models/ComputerUse';
 import {AGENT_SERVICE} from '../../core/services/interfaces/agent';
 import {FEATURE_FLAG_SERVICE} from '../../core/services/interfaces/feature-flag';
 import {FEEDBACK_SERVICE} from '../../core/services/interfaces/feedback';
 import {SAFE_VALUES_SERVICE, SafeValuesService} from '../../core/services/interfaces/safevalues';
 import {SESSION_SERVICE} from '../../core/services/interfaces/session';
 import {STRING_TO_COLOR_SERVICE} from '../../core/services/interfaces/string-to-color';
+import {THEME_SERVICE} from '../../core/services/interfaces/theme';
 import {UI_STATE_SERVICE} from '../../core/services/interfaces/ui-state';
 import {MockAgentService} from '../../core/services/testing/mock-agent.service';
 import {MockFeatureFlagService} from '../../core/services/testing/mock-feature-flag.service';
 import {MockFeedbackService} from '../../core/services/testing/mock-feedback.service';
 import {MockSessionService} from '../../core/services/testing/mock-session.service';
 import {MockStringToColorService} from '../../core/services/testing/mock-string-to-color.service';
+import {MockThemeService} from '../../core/services/testing/mock-theme.service';
 import {MockUiStateService} from '../../core/services/testing/mock-ui-state.service';
 import {fakeAsync, initTestBed, tick} from '../../testing/utils';
 import {MARKDOWN_COMPONENT} from '../markdown/markdown.component.interface';
 import {MockMarkdownComponent} from '../markdown/testing/mock-markdown.component';
 
 import {ChatPanelComponent} from './chat-panel.component';
-
-
-function createUiEvents(arr: any[]): UiEvent[] {
-  return arr.map(obj => {
-    if (obj instanceof UiEvent) return obj;
-    if (obj.eventId) {
-      obj.event = {id: obj.eventId};
-      delete obj.eventId;
-    }
-    return new UiEvent(obj);
-  });
-}
 
 describe('ChatPanelComponent', () => {
   let component: ChatPanelComponent;
@@ -111,6 +104,8 @@ describe('ChatPanelComponent', () => {
             {provide: SESSION_SERVICE, useValue: mockSessionService},
             {provide: FEEDBACK_SERVICE, useValue: mockFeedbackService},
             {provide: SAFE_VALUES_SERVICE, useValue: mockSafeValuesService},
+            {provide: THEME_SERVICE, useClass: MockThemeService},
+            {provide: ARTIFACT_SERVICE, useValue: new MockArtifactService()},
           ],
         })
         .compileComponents();
@@ -138,34 +133,36 @@ describe('ChatPanelComponent', () => {
       expect(component.sendMessage.emit).toHaveBeenCalledWith(mockEvent);
     });
 
-    it('should display user and bot messages', async () => {
-      component.uiEvents = createUiEvents([
-        {role: 'user', text: 'User message'},
-        {role: 'bot', text: 'Bot message'},
-      ]);
+    xit('should display user and bot messages', async () => {
+      component.uiEvents = [
+        new UiEvent({role: 'user', text: 'User message', event: {} as any}),
+        new UiEvent({role: 'bot', text: 'Bot message', event: {} as any}),
+      ];
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
-      const messages = fixture.debugElement.queryAll(By.css('.message-card'));
-      expect(messages.length).toBe(2);
-      expect(messages[0].nativeElement.textContent).toContain('User message');
-      expect(messages[1].nativeElement.textContent).toContain('Bot message');
+      const uiEvents = fixture.debugElement.queryAll(By.css('.content-bubble'));
+      expect(uiEvents.length).toBe(2);
+      expect(uiEvents[0].nativeElement.textContent).toContain('User message');
+      expect(uiEvents[1].nativeElement.textContent).toContain('Bot message');
     });
 
-    it('should display function call', () => {
-      component.uiEvents = createUiEvents([
-        {role: 'bot', functionCalls: [{name: 'test_func', args: {}}]},
-      ]);
+    // Skipped: .function-event-button UI element removed in UI refactor
+    xit('should display function call', () => {
+      component.uiEvents = [
+        new UiEvent({role: 'bot', functionCalls: [{name: 'test_func', args: {}}], event: {} as any}),
+      ];
       fixture.detectChanges();
       const button =
           fixture.debugElement.query(By.css('.function-event-button'));
       expect(button.nativeElement.textContent).toContain('test_func');
     });
 
-    it('should display function response', () => {
-      component.uiEvents = createUiEvents([
-        {role: 'bot', functionResponses: [{name: 'test_func', response: {}}]},
-      ]);
+    // Skipped: .function-event-button UI element removed in UI refactor
+    xit('should display function response', () => {
+      component.uiEvents = [
+        new UiEvent({role: 'bot', functionResponses: [{name: 'test_func', response: {}}], event: {} as any}),
+      ];
       fixture.detectChanges();
       const button =
           fixture.debugElement.query(By.css('.function-event-button'));
@@ -186,22 +183,24 @@ describe('ChatPanelComponent', () => {
       expect(component.removeFile.emit).toHaveBeenCalledWith(0);
     });
 
-    it('should display A2UI canvas', () => {
-      component.uiEvents = createUiEvents([
-        {
+    xit('should display A2UI canvas', () => {
+      component.uiEvents = [
+        new UiEvent({
           role: 'bot',
           a2uiData:
-              {beginRendering: true, surfaceUpdate: {}, dataModelUpdate: {}}
-        },
-      ]);
+              {beginRendering: true, surfaceUpdate: {}, dataModelUpdate: {}},
+          event: {} as any
+        }),
+      ];
       fixture.detectChanges();
       const canvas = fixture.debugElement.query(By.css('app-a2ui-canvas'));
       expect(canvas).toBeTruthy();
     });
   });
 
-  it('should display loading bar if message isLoading', async () => {
-    component.uiEvents = createUiEvents([{role: 'bot', isLoading: true}]);
+  // Skipped: mat-progress-bar for loading messages removed in UI refactor
+  xit('should display loading bar if message isLoading', async () => {
+    component.uiEvents = [new UiEvent({role: 'bot', isLoading: true, event: {} as any})];
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -209,9 +208,9 @@ describe('ChatPanelComponent', () => {
     expect(progressBar).toBeTruthy();
   });
 
-  it('should display thought chip for thought messages', async () => {
-    component.uiEvents =
-        createUiEvents([{role: 'bot', text: 'Thinking...', thought: true}]);
+  // Skipped: .thought-chip UI element removed in UI refactor
+  xit('should display thought chip for thought messages', async () => {
+    component.uiEvents = [new UiEvent({role: 'bot', text: 'Thinking...', thought: true, event: {} as any})];
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -231,10 +230,10 @@ describe('ChatPanelComponent', () => {
       component.isEvalEditMode = true;
     });
 
-    it(
+    xit(
         'should show edit/delete buttons for text messages', async () => {
-          component.uiEvents = createUiEvents(
-              [{role: 'bot', text: 'eval message', eventId: '1'}]);
+          component.uiEvents =
+              [new UiEvent({role: 'bot', text: 'eval message', event: { id: '1' } as any})];
           fixture.detectChanges();
           await fixture.whenStable();
           fixture.detectChanges();
@@ -245,9 +244,9 @@ describe('ChatPanelComponent', () => {
           expect(buttons[1].nativeElement.textContent).toContain('delete');
         });
 
-    it('should show edit button for function calls', async () => {
-      component.uiEvents = createUiEvents(
-          [{role: 'bot', functionCalls: [{name: 'func1'}], eventId: '1'}]);
+    xit('should show edit button for function calls', async () => {
+      component.uiEvents =
+          [new UiEvent({role: 'bot', functionCalls: [{name: 'func1', args: {}}], event: { id: '1' } as any})];
       component.isEditFunctionArgsEnabled = true;
       fixture.detectChanges();
       await fixture.whenStable();
@@ -258,10 +257,10 @@ describe('ChatPanelComponent', () => {
       expect(buttons[0].nativeElement.textContent).toContain('edit');
     });
 
-    it(
+    xit(
         'should emit editEvalCaseMessage when edit is clicked', async () => {
-          const message = {role: 'bot', text: 'eval message', eventId: '1'};
-          component.uiEvents = createUiEvents([message]);
+          const message = new UiEvent({role: 'bot', text: 'eval message', event: { id: '1' } as any});
+          component.uiEvents = [message];
           spyOn(component.editEvalCaseMessage, 'emit');
           fixture.detectChanges();
           await fixture.whenStable();
@@ -273,11 +272,11 @@ describe('ChatPanelComponent', () => {
               .toHaveBeenCalledWith(message);
         });
 
-    it(
+    xit(
         'should emit deleteEvalCaseMessage when delete is clicked',
         async () => {
-          const message = {role: 'bot', text: 'eval message', eventId: '1'};
-          component.uiEvents = createUiEvents([message]);
+          const message = new UiEvent({role: 'bot', text: 'eval message', event: { id: '1' } as any});
+          component.uiEvents = [message];
           spyOn(component.deleteEvalCaseMessage, 'emit');
           fixture.detectChanges();
           await fixture.whenStable();
@@ -289,15 +288,15 @@ describe('ChatPanelComponent', () => {
               .toHaveBeenCalledWith({message, index: 0});
         });
 
-    it(
+    xit(
         'should emit editFunctionArgs when edit on function call is clicked',
         async () => {
-          const message = {
+          const message = new UiEvent({
             role: 'bot',
-            functionCalls: [{name: 'func1'}],
-            eventId: '1'
-          };
-          component.uiEvents = createUiEvents([message]);
+            functionCalls: [{name: 'func1', args: {}}],
+            event: { id: '1' } as any
+          });
+          component.uiEvents = [message];
           component.isEditFunctionArgsEnabled = true;
           spyOn(component.editFunctionArgs, 'emit');
           fixture.detectChanges();
@@ -310,10 +309,10 @@ describe('ChatPanelComponent', () => {
         });
   });
 
-  describe('Events', () => {
+  // Skipped: Bot icon (mat-mini-fab) and function-event-button removed in UI refactor
+  xdescribe('Events', () => {
     it('should emit clickEvent when bot icon is clicked', () => {
-      component.uiEvents =
-          createUiEvents([{role: 'bot', text: 'message', eventId: '1'}]);
+      component.uiEvents = [new UiEvent({role: 'bot', text: 'message', event: { id: '1', author: 'bot' } as any})];
       spyOn(component.clickEvent, 'emit');
       fixture.detectChanges();
       const botIcon =
@@ -323,7 +322,7 @@ describe('ChatPanelComponent', () => {
     });
 
     it('should disable bot icon when eventId is not set', () => {
-      component.uiEvents = createUiEvents([{role: 'bot', text: 'message'}]);
+      component.uiEvents = [new UiEvent({role: 'bot', text: 'message', event: {} as any})];
       fixture.detectChanges();
       const botIcon =
           fixture.debugElement.query(By.css('button[mat-mini-fab]'));
@@ -332,8 +331,8 @@ describe('ChatPanelComponent', () => {
 
     it(
         'should emit clickEvent when function call button is clicked', () => {
-          component.uiEvents = createUiEvents(
-              [{role: 'bot', functionCalls: [{name: 'func1'}], eventId: '1'}]);
+          component.uiEvents =
+              [new UiEvent({role: 'bot', functionCalls: [{name: 'func1', args: {}}], event: { id: '1', author: 'bot' } as any})];
           spyOn(component.clickEvent, 'emit');
           fixture.detectChanges();
           const funcButton =
@@ -369,13 +368,13 @@ describe('ChatPanelComponent', () => {
       let scrollContainerElement: HTMLElement;
 
       beforeEach(() => {
-        component.uiEvents =
-            createUiEvents([{role: 'bot', text: 'Bot message'}]);
+        component.uiEvents = [new UiEvent({role: 'bot', text: 'Bot message', event: {} as any})];
         fixture.detectChanges();
         scrollContainerElement = component.scrollContainer.nativeElement;
       });
 
-      it(
+      // Skipped: Scroll interrupt behavior changed in UI refactor
+      xit(
           'should scroll to bottom when user sends a message, even if scroll was interrupted',
           fakeAsync(() => {
             spyOn(scrollContainerElement, 'scrollTo');
@@ -383,10 +382,9 @@ describe('ChatPanelComponent', () => {
             expect(component.scrollInterrupted).toBeTrue();
 
             const oldMessages = component.uiEvents;
-            component.uiEvents =
-                createUiEvents([...oldMessages, {role: 'user', text: 'User'}]);
+            component.uiEvents = [...oldMessages, new UiEvent({role: 'user', text: 'User', event: {} as any})];
             component.ngOnChanges({
-              'uiEvents':
+              'messages':
                   new SimpleChange(oldMessages, component.uiEvents, false)
             });
             fixture.detectChanges();
@@ -400,10 +398,10 @@ describe('ChatPanelComponent', () => {
           'should call uiStateService.lazyLoadMessages when scrolled to top',
           fakeAsync(() => {
             const initialMessageCount = 50;
-            const initialMessages = createUiEvents(Array.from(
+            const initialMessages = Array.from(
                 {length: initialMessageCount},
-                (_, i) => ({role: 'bot', text: `message ${i}`})));
-            component.uiEvents = createUiEvents(initialMessages);
+                (_, i) => new UiEvent({role: 'bot', text: `message ${i}`, event: {} as any}));
+            component.uiEvents = initialMessages;
             fixture.detectChanges();
 
             scrollContainerElement.style.height = '100px';
@@ -423,10 +421,9 @@ describe('ChatPanelComponent', () => {
 
             mockUiStateService.lazyLoadMessagesResponse.next();
 
-            const newMessages = createUiEvents(Array.from(
-                {length: 20}, (_, i) => ({role: 'bot', text: `new ${i}`})));
-            component.uiEvents =
-                createUiEvents([...newMessages, ...component.uiEvents]);
+            const newMessages = Array.from(
+                {length: 20}, (_, i) => new UiEvent({role: 'bot', text: `new ${i}`, event: {} as any}));
+            component.uiEvents = [...newMessages, ...component.uiEvents];
             mockUiStateService.newMessagesLoadedResponse.next(
                 {items: newMessages, nextPageToken: 'next'});
             tick();
@@ -501,7 +498,7 @@ describe('ChatPanelComponent', () => {
                           scrollContainer, 'scrollHeight',
                           {value: 1500, configurable: true});
                       mockUiStateService.newMessagesLoadedResponse.next({
-                        items: [{role: 'bot', text: 'message 1'}],
+                        items: [new UiEvent({role: 'bot', text: 'message 1', event: {} as any})],
                         nextPageToken: nextToken
                       });
 
@@ -594,12 +591,13 @@ describe('ChatPanelComponent', () => {
       const button = allButtons.find(
           b =>
               b.nativeElement.querySelector('mat-icon')?.textContent?.trim() ===
-              'mic');
+              'call');
       expect(button!.nativeElement.disabled).toBeTrue();
     });
 
     it('should have the videocam button disabled', () => {
       mockFeatureFlagService.isBidiStreamingEnabledResponse.next(false);
+      component.isAudioRecording = true;
       fixture.detectChanges();
 
       const allButtons =
@@ -635,7 +633,8 @@ describe('ChatPanelComponent', () => {
       });
     });
 
-    describe('when more options button is hidden', () => {
+    // Skipped: More options button behavior changed in UI refactor
+    xdescribe('when more options button is hidden', () => {
       beforeEach(() => {
         mockFeatureFlagService.isMoreOptionsButtonHiddenResponse.next(true);
         fixture.detectChanges();
@@ -695,8 +694,8 @@ describe('ChatPanelComponent', () => {
   });
 
   describe('Feedback UI', () => {
-    it('should show when feature flag is on', () => {
-      component.uiEvents = createUiEvents([{role: 'bot', text: 'message'}]);
+    xit('should show when feature flag is on', () => {
+      component.uiEvents = [new UiEvent({role: 'bot', text: 'message', event: {} as any})];
 
       mockFeatureFlagService.isFeedbackServiceEnabledResponse.next(true);
       fixture.detectChanges();
@@ -707,7 +706,7 @@ describe('ChatPanelComponent', () => {
     });
 
     it('should hide when feature flag is off', () => {
-      component.uiEvents = createUiEvents([{role: 'bot', text: 'message'}]);
+      component.uiEvents = [new UiEvent({role: 'bot', text: 'message', event: {} as any})];
 
       mockFeatureFlagService.isFeedbackServiceEnabledResponse.next(false);
       fixture.detectChanges();
@@ -718,7 +717,7 @@ describe('ChatPanelComponent', () => {
     });
 
     it('should hide when agent response is loading', () => {
-      component.uiEvents = createUiEvents([{role: 'bot', text: 'message'}]);
+      component.uiEvents = [new UiEvent({role: 'bot', text: 'message', event: {} as any})];
 
       mockAgentService.getLoadingStateResponse.next(true);
       fixture.detectChanges();
@@ -728,14 +727,14 @@ describe('ChatPanelComponent', () => {
       expect(feedbackButtons).toBeFalsy();
     });
 
-    it('should show after each bot message', () => {
-      component.uiEvents = createUiEvents([
-        {role: 'bot', text: 'message 1'},
-        {role: 'bot', text: 'message 1'},
-        {role: 'user', text: 'message 2'},
-        {role: 'bot', text: 'message 1'},
-        {role: 'bot', text: 'message 1'},
-      ]);
+    xit('should show after each bot message', () => {
+      component.uiEvents = [
+        new UiEvent({role: 'bot', text: 'message 1', event: {} as any}),
+        new UiEvent({role: 'bot', text: 'message 1', event: {} as any}),
+        new UiEvent({role: 'user', text: 'message 2', event: {} as any}),
+        new UiEvent({role: 'bot', text: 'message 1', event: {} as any}),
+        new UiEvent({role: 'bot', text: 'message 1', event: {} as any}),
+      ];
       fixture.detectChanges();
 
       let feedbackButtons =
@@ -744,5 +743,28 @@ describe('ChatPanelComponent', () => {
     });
   });
 
+  describe('Computer Use', () => {
+    it(
+        'isComputerUseResponse should return true when image data and url are present',
+        () => {
+          const response: any = {
+            name: 'computer_use',
+            response: {
+              image: {data: 'base64data', mimetype: 'image/png'},
+              url: 'http://example.com'
+            }
+          };
+          expect(isComputerUseResponse(response)).toBeTrue();
+        });
 
+    it(
+        'isComputerUseResponse should return false when image data is missing',
+        () => {
+          const response: any = {
+            name: 'computer_use',
+            response: {image: null, url: 'http://example.com'}
+          };
+          expect(isComputerUseResponse(response)).toBeFalse();
+        });
+  });
 });

--- a/src/app/components/chat-panel/chat-panel.component.ts
+++ b/src/app/components/chat-panel/chat-panel.component.ts
@@ -58,7 +58,7 @@ import { MediaType, } from '../artifact-tab/artifact-tab.component';
 import { AudioPlayerComponent } from '../audio-player/audio-player.component';
 import { ComputerActionComponent } from '../computer-action/computer-action.component';
 import { LongRunningResponseComponent } from '../long-running-response/long-running-response';
-import { MarkdownComponent } from '../markdown/markdown.component';
+import { MARKDOWN_COMPONENT, MarkdownComponentInterface } from '../markdown/markdown.component.interface';
 import { MessageFeedbackComponent } from '../message-feedback/message-feedback.component';
 
 import { ChatPanelMessagesInjectionToken } from './chat-panel.component.i18n';

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -1832,7 +1832,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       }
 
       const a2uiData: any = {};
-      (parsed as any[]).forEach((msg: any) => {
+      parsed.forEach((msg: any) => {
         if (msg.beginRendering) {
           a2uiData.beginRendering = msg;
         } else if (msg.surfaceUpdate) {
@@ -3904,7 +3904,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!allRunNodeNames || allRunNodeNames.length === 0) return svgString;
 
     const parser = new DOMParser();
-    const doc = (parser as any)['parseFromString'](svgString, 'image/svg+xml');
+    const doc = parser.parseFromString(svgString, 'image/svg+xml');
 
     const reverseAdjacencyList = new Map<string, string[]>();
     const forwardAdjacencyList = new Map<string, string[]>();
@@ -4179,7 +4179,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   private applyV1Highlighting(svgString: string, highlightPairs: [string, string][], isDarkMode: boolean): string {
     const parser = new DOMParser();
-    const doc = (parser as any)['parseFromString'](svgString, 'image/svg+xml');
+    const doc = parser.parseFromString(svgString, 'image/svg+xml');
 
     const darkGreen = '#0F5223';
     const lightGreen = '#69CB87';

--- a/src/app/components/code-editor/code-editor.component.ts
+++ b/src/app/components/code-editor/code-editor.component.ts
@@ -15,14 +15,24 @@
  * limitations under the License.
  */
 
-import {AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnDestroy, Output, ViewChild,} from '@angular/core';
-import {python} from '@codemirror/lang-python';
+import {
+  ChangeDetectionStrategy,
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import {HighlightStyle, syntaxHighlighting, syntaxTree} from '@codemirror/language';
+import {python} from '@codemirror/lang-python';
+import {tags} from '@lezer/highlight';
 import {Diagnostic, linter, lintGutter} from '@codemirror/lint';
-import {basicSetup} from 'codemirror';
 import {EditorState} from '@codemirror/state';
 import {EditorView} from '@codemirror/view';
-import {tags} from '@lezer/highlight';
+import {basicSetup} from 'codemirror';
 
 /** A dark theme for the Python syntax highlighting. */
 const pythonDarkHighlightStyle = HighlightStyle.define([

--- a/src/app/components/computer-action/computer-action.component.spec.ts
+++ b/src/app/components/computer-action/computer-action.component.spec.ts
@@ -136,5 +136,72 @@ describe('ComputerActionComponent', () => {
       const screenshot = component.getPreviousComputerUseScreenshot();
       expect(screenshot).toContain('img1');
     });
+
+    it('should find screenshot in parts of functionResponses', () => {
+      component.index = 1;
+      component.allMessages = [
+        {
+          functionResponses: [
+            {
+              name: 'computer',
+              parts: [
+                {
+                  inlineData: {
+                    mimeType: 'image/png',
+                    data: 'base64data_in_parts'
+                  }
+                }
+              ]
+            } as any
+          ]
+        }
+      ];
+
+      const screenshot = component.getPreviousComputerUseScreenshot();
+      expect(screenshot).toBe('data:image/png;base64,base64data/in/parts');
+    });
+  });
+
+  describe('Fallback Display', () => {
+    it('should show fallback text when no screenshot is found', () => {
+      component.index = 0;
+      component.allMessages = [];
+      component.functionCall = {
+        name: ComputerTool.CLICK_AT,
+        args: {x: 100, y: 100}
+      };
+      fixture.detectChanges();
+      
+      const fallbackText = fixture.debugElement.query(By.css('.fallback-text'));
+      expect(fallbackText).toBeTruthy();
+      expect(fallbackText.nativeElement.textContent).toContain('No screenshot');
+    });
+  });
+
+  describe('getAllComputerUseCoordinates', () => {
+    it('should associate coordinates with the previous image', () => {
+      component.allMessages = [
+        {
+          functionResponses: [
+            {name: 'computer', response: {image: {data: 'img1'}}}
+          ]
+        },
+        {
+          functionCalls: [
+            {name: 'computer', args: {action: 'left_click', coordinate: [500, 500]}}
+          ]
+        },
+        {
+          functionResponses: [
+            {name: 'computer', response: {image: {data: 'img2'}}}
+          ]
+        }
+      ];
+
+      const coords = component.getAllComputerUseCoordinates();
+      expect(coords.length).toBe(2);
+      expect(coords[0]).toEqual({x: 500, y: 500});
+      expect(coords[1]).toBeNull();
+    });
   });
 });

--- a/src/app/components/custom-json-viewer/custom-json-viewer.component.ts
+++ b/src/app/components/custom-json-viewer/custom-json-viewer.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject, Type } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -32,6 +32,7 @@ import { MarkdownComponent } from '../markdown/markdown.component';
     MatDialogModule,
     MatIcon,
     MatIconButton,
+    MarkdownComponent
   ],
   template: `
     <div class="md-dialog-header">
@@ -82,7 +83,6 @@ import { MarkdownComponent } from '../markdown/markdown.component';
   `]
 })
 export class MarkdownPreviewDialogComponent {
-  readonly markdownComponent: Type<MarkdownComponentInterface> = inject(MARKDOWN_COMPONENT);
   dialogRef = inject(MatDialogRef<MarkdownPreviewDialogComponent>);
   data = inject(MAT_DIALOG_DATA) as { key: string; value: string };
 

--- a/src/app/components/edit-json-dialog/edit-json-dialog.component.ts
+++ b/src/app/components/edit-json-dialog/edit-json-dialog.component.ts
@@ -18,7 +18,7 @@
 import {ChangeDetectionStrategy, Component, Inject, inject, OnInit, viewChild} from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 
-import {JsonEditorComponent} from '../json-editor/json-editor.component.google';
+import {JsonEditorComponent} from '../json-editor/json-editor.component';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import {EditJsonDialogMessagesInjectionToken} from './edit-json-dialog.component.i18n';
 import { MatButton } from '@angular/material/button';

--- a/src/app/components/eval-tab/add-eval-session-dialog/add-eval-session-dialog/add-eval-session-dialog.component.spec.ts
+++ b/src/app/components/eval-tab/add-eval-session-dialog/add-eval-session-dialog/add-eval-session-dialog.component.spec.ts
@@ -64,4 +64,30 @@ describe('AddEvalSessionDialogComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should ask for confirmation if case already exists and not proceed if cancelled', () => {
+    spyOn(window, 'confirm').and.returnValue(false);
+    const evalService = TestBed.inject(EVAL_SERVICE) as unknown as jasmine.SpyObj<any>;
+    
+    component.data.existingCases = ['existing_case'];
+    component.newCaseId = 'existing_case';
+    
+    component.createNewEvalCase();
+    
+    expect(window.confirm).toHaveBeenCalled();
+    expect(evalService.addCurrentSession).not.toHaveBeenCalled();
+  });
+
+  it('should ask for confirmation if case already exists and proceed if confirmed', () => {
+    spyOn(window, 'confirm').and.returnValue(true);
+    const evalService = TestBed.inject(EVAL_SERVICE) as unknown as jasmine.SpyObj<any>;
+    
+    component.data.existingCases = ['existing_case'];
+    component.newCaseId = 'existing_case';
+    
+    component.createNewEvalCase();
+    
+    expect(window.confirm).toHaveBeenCalled();
+    expect(evalService.addCurrentSession).toHaveBeenCalled();
+  });
 });

--- a/src/app/components/eval-tab/eval-tab.component.spec.ts
+++ b/src/app/components/eval-tab/eval-tab.component.spec.ts
@@ -66,11 +66,13 @@ describe('EvalTabComponent', () => {
       'isEditFunctionArgsEnabled',
       'isSessionUrlEnabled',
       'isA2ACardEnabled',
+      'isEvalV2Enabled',
     ]);
     featureFlagService.isImportSessionEnabled.and.returnValue(of(false));
     featureFlagService.isEditFunctionArgsEnabled.and.returnValue(of(false));
     featureFlagService.isSessionUrlEnabled.and.returnValue(of(false));
     featureFlagService.isA2ACardEnabled.and.returnValue(of(false));
+    featureFlagService.isEvalV2Enabled.and.returnValue(of(false));
 
     await TestBed.configureTestingModule({
       imports: [MatDialogModule, EvalTabComponent, NoopAnimationsModule],
@@ -96,6 +98,36 @@ describe('EvalTabComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should reset selectedEvalCase when clicking cases tab', () => {
+    component.selectedEvalSet.set('test-set');
+    component.evalsets = ['test-set'];
+    fixture.detectChanges();
+    
+    component.selectedEvalCase.set({ evalId: 'test-case' } as any);
+    
+    const buttons = fixture.nativeElement.querySelectorAll('.vertical-tabs-sidebar button');
+    const casesButton = buttons[1] as HTMLButtonElement;
+    casesButton.click();
+    fixture.detectChanges();
+    
+    expect(component.selectedEvalCase()).toBeNull();
+  });
+
+  it('should reset selectedHistoryRun when clicking history tab', () => {
+    component.selectedEvalSet.set('test-set');
+    component.evalsets = ['test-set'];
+    fixture.detectChanges();
+    
+    component.selectedHistoryRun.set('test-run');
+    
+    const buttons = fixture.nativeElement.querySelectorAll('.vertical-tabs-sidebar button');
+    const historyButton = buttons[2] as HTMLButtonElement;
+    historyButton.click();
+    fixture.detectChanges();
+    
+    expect(component.selectedHistoryRun()).toBeNull();
   });
 
   it('runs against the selected set id when one is selected', () => {

--- a/src/app/components/eval-tab/new-eval-set-dialog/new-eval-set-dialog-component/new-eval-set-dialog-component.component.spec.ts
+++ b/src/app/components/eval-tab/new-eval-set-dialog/new-eval-set-dialog-component/new-eval-set-dialog-component.component.spec.ts
@@ -26,6 +26,7 @@ import { EvalService } from '../../../../core/services/eval.service';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import {EVAL_SERVICE} from '../../../../core/services/interfaces/eval';
+import {FEATURE_FLAG_SERVICE} from '../../../../core/services/interfaces/feature-flag';
 import {AnalyticsService} from '../../../../core/services/analytics.service';
 
 describe('NewEvalSetDialogComponentComponent', () => {
@@ -39,6 +40,9 @@ describe('NewEvalSetDialogComponentComponent', () => {
     const evalService = jasmine.createSpyObj<EvalService>(['createNewEvalSet']);
     evalService.createNewEvalSet.and.returnValue(of({}));
 
+    const featureFlagService = jasmine.createSpyObj('FeatureFlagService', ['isEvalV2Enabled']);
+    featureFlagService.isEvalV2Enabled.and.returnValue(of(false));
+
     await TestBed.configureTestingModule({
       imports: [
         MatDialogModule,
@@ -49,6 +53,7 @@ describe('NewEvalSetDialogComponentComponent', () => {
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: EVAL_SERVICE, useValue: evalService },
+        { provide: FEATURE_FLAG_SERVICE, useValue: featureFlagService },
         {provide: AnalyticsService, useValue: jasmine.createSpyObj('AnalyticsService', ['setUserProperties', 'sendEvent'])}
       ],
     }).compileComponents();

--- a/src/app/components/info-table/info-table.spec.ts
+++ b/src/app/components/info-table/info-table.spec.ts
@@ -1,0 +1,26 @@
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+import {initTestBed} from '../../testing/utils';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InfoTable } from './info-table';
+
+describe('InfoTable', () => {
+  let component: InfoTable;
+  let fixture: ComponentFixture<InfoTable>;
+
+  beforeEach(async () => {
+    initTestBed();  // required for 1p compat
+    await TestBed.configureTestingModule({
+      imports: [InfoTable]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(InfoTable);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/invocation-menu/invocation-menu.spec.ts
+++ b/src/app/components/invocation-menu/invocation-menu.spec.ts
@@ -1,0 +1,26 @@
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+import {initTestBed} from '../../testing/utils';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InvocationMenu } from './invocation-menu';
+
+describe('InvocationMenu', () => {
+  let component: InvocationMenu;
+  let fixture: ComponentFixture<InvocationMenu>;
+
+  beforeEach(async () => {
+    initTestBed();  // required for 1p compat
+    await TestBed.configureTestingModule({
+      imports: [InvocationMenu]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(InvocationMenu);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/long-running-response/long-running-response.ts
+++ b/src/app/components/long-running-response/long-running-response.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges, Type } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CustomJsonViewerComponent } from '../custom-json-viewer/custom-json-viewer.component';
 import { MatButton, MatIconButton } from '@angular/material/button';
@@ -39,12 +38,11 @@ import { MarkdownComponent } from '../markdown/markdown.component';
     MatIconButton,
     MatButton,
     MatIcon,
-    CommonModule,
+    MarkdownComponent,
     CustomJsonViewerComponent,
   ],
 })
 export class LongRunningResponseComponent implements OnChanges {
-  readonly markdownComponent: Type<MarkdownComponentInterface> = inject(MARKDOWN_COMPONENT);
   @Input() functionCall: any;
   @Input() appName!: string;
   @Input() userId!: string;

--- a/src/app/components/markdown/markdown.component.spec.ts
+++ b/src/app/components/markdown/markdown.component.spec.ts
@@ -54,7 +54,8 @@ describe('MarkdownComponent', () => {
        expect(element.querySelector('strong')?.textContent).toBe('bold');
      }));
 
-  it('should apply italic style when thought is true', () => {
+  // Skipped: Thought styling removed in UI refactor
+  xit('should apply italic style when thought is true', () => {
     fixture.componentRef.setInput('thought', true);
     fixture.detectChanges();
     const markdownElement: HTMLElement|null =
@@ -63,7 +64,8 @@ describe('MarkdownComponent', () => {
     expect(markdownElement?.style.color).toBe('rgb(154, 160, 166)');
   });
 
-  it('should apply normal style when thought is false', () => {
+  // Skipped: Thought styling removed in UI refactor
+  xit('should apply normal style when thought is false', () => {
     fixture.componentRef.setInput('thought', false);
     fixture.detectChanges();
     const markdownElement: HTMLElement|null =

--- a/src/app/components/message-feedback/message-feedback.component.spec.ts
+++ b/src/app/components/message-feedback/message-feedback.component.spec.ts
@@ -18,7 +18,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 // 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it,}
-import {BehaviorSubject, NEVER, of, throwError} from 'rxjs';
+import {BehaviorSubject, NEVER, of} from 'rxjs';
 
 import {Feedback, FEEDBACK_SERVICE} from '../../core/services/interfaces/feedback';
 import {MockFeedbackService} from '../../core/services/testing/mock-feedback.service';
@@ -113,7 +113,7 @@ describe('MessageFeedbackComponent', () => {
            .toContain('thumb_up');
      });
 
-  it('should open detailed panel without sending feedback when "up" button is clicked',
+  it('should submit "up" feedback and show detailed panel when "up" button is clicked',
      () => {
        expect(fixture.debugElement.query(By.css('.feedback-details-container')))
            .toBeFalsy();
@@ -124,12 +124,12 @@ describe('MessageFeedbackComponent', () => {
 
        expect(fixture.debugElement.query(By.css('.feedback-details-container')))
            .toBeTruthy();
-       // The thumb click MUST NOT call sendFeedback. The write is deferred to
-       // the dialog Submit so the user can attach labels in a single RPC.
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
+       expect(mockFeedbackService.sendFeedback)
+           .toHaveBeenCalledWith(
+               'test-session', 'test-event', {direction: 'up'});
      });
 
-  it('should open detailed panel without sending feedback when "down" button is clicked',
+  it('should submit "down" feedback and show detailed panel when "down" button is clicked',
      () => {
        expect(fixture.debugElement.query(By.css('.feedback-details-container')))
            .toBeFalsy();
@@ -142,129 +142,70 @@ describe('MessageFeedbackComponent', () => {
            .toBeTruthy();
        expect(fixture.debugElement.query(By.css('.feedback-buttons')))
            .toBeTruthy();
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
-     });
-
-  it('should toggle between detailed feedback directions without sending feedback',
-     () => {
-       fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
-           .nativeElement.click();  // Open down panel
-       fixture.detectChanges();
-       expect(fixture.debugElement
-                  .queryAll(By.css('.feedback-buttons button mat-icon'))[1]
-                  .nativeElement.textContent)
-           .toContain('thumb_down_filled');
-
-       fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
-           .nativeElement.click();  // Switch to up
-       fixture.detectChanges();
-
-       expect(fixture.debugElement
-                  .queryAll(By.css('.feedback-buttons button mat-icon'))[0]
-                  .nativeElement.textContent)
-           .toContain('thumb_up_filled');
-       expect(fixture.debugElement
-                  .queryAll(By.css('.feedback-buttons button mat-icon'))[1]
-                  .nativeElement.textContent)
-           .toContain('thumb_down');
-       expect(fixture.debugElement.query(By.css('.feedback-details-container')))
-           .toBeTruthy();
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
-     });
-
-  it('should call sendFeedback exactly once when detailed feedback is submitted',
-     () => {
-       fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
-           .nativeElement.click();  // Click up: opens dialog, no RPC.
-       fixture.detectChanges();
-
-       expect(fixture.debugElement.query(By.css('.feedback-details-container')))
-           .toBeTruthy();
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
-
-       // Fill in feedback
-       const textarea =
-           fixture.debugElement.query(By.css('textarea')).nativeElement as
-           HTMLTextAreaElement;
-       textarea.value = 'test comment';
-       textarea.dispatchEvent(new Event('input'));
-       fixture.detectChanges();
-
-       fixture.debugElement.queryAll(By.css('.actions button'))[1]
-           .nativeElement.click();  // Submit button
-       fixture.detectChanges();
-
        expect(mockFeedbackService.sendFeedback)
-           .toHaveBeenCalledOnceWith('test-session', 'test-event', {
-             direction: 'up',
-             reasons: [],
-             comment: 'test comment',
-           });
-       expect(fixture.debugElement.query(By.css('.feedback-details-container')))
-           .toBeFalsy();
-       expect(fixture.debugElement
-                  .queryAll(By.css('.feedback-buttons button mat-icon'))[0]
-                  .nativeElement.textContent)
-           .toContain('thumb_up_filled');
+           .toHaveBeenCalledWith(
+               'test-session', 'test-event', {direction: 'down'});
      });
 
-  it('should pre-populate dialog from existing feedback when thumb is clicked',
-     () => {
-       getFeedback$.next({
-         id: 'f1',
-         direction: 'up',
-         reasons: ['Factually correct'],
-         comment: 'prior comment',
-       });
-       fixture.detectChanges();
-
-       // Click DOWN to switch direction. Dialog should open pre-populated
-       // with the existing reasons + comment so Submit issues a single
-       // UpdateFeedback (no orphan CreateFeedback on the thumb click).
-       fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
-           .nativeElement.click();
-       fixture.detectChanges();
-
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
-       const textarea =
-           fixture.debugElement.query(By.css('textarea')).nativeElement as
-           HTMLTextAreaElement;
-       expect(textarea.value).toBe('prior comment');
-
-       fixture.debugElement.queryAll(By.css('.actions button'))[1]
-           .nativeElement.click();  // Submit button
-       fixture.detectChanges();
-
-       expect(mockFeedbackService.sendFeedback)
-           .toHaveBeenCalledOnceWith('test-session', 'test-event', {
-             direction: 'down',
-             reasons: ['Factually correct'],
-             comment: 'prior comment',
-           });
-     });
-
-  it('should keep dialog open on submit failure so the user can retry', () => {
-    mockFeedbackService.sendFeedback.and.returnValue(
-        throwError(() => new Error('rpc failed')));
+  it('should toggle between detailed feedback directions', () => {
+    fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
+        .nativeElement.click();  // Open down panel
+    fixture.detectChanges();
+    expect(fixture.debugElement
+               .queryAll(By.css('.feedback-buttons button mat-icon'))[1]
+               .nativeElement.textContent)
+        .toContain('thumb_down_filled');
 
     fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
-        .nativeElement.click();
+        .nativeElement.click();  // Switch to up
+    fixture.detectChanges();
+
+    expect(fixture.debugElement
+               .queryAll(By.css('.feedback-buttons button mat-icon'))[0]
+               .nativeElement.textContent)
+        .toContain('thumb_up_filled');
+    expect(fixture.debugElement
+               .queryAll(By.css('.feedback-buttons button mat-icon'))[1]
+               .nativeElement.textContent)
+        .toContain('thumb_down');
+    expect(fixture.debugElement.query(By.css('.feedback-details-container')))
+        .toBeTruthy();
+    expect(mockFeedbackService.sendFeedback)
+        .toHaveBeenCalledWith('test-session', 'test-event', {direction: 'up'});
+  });
+
+  it('should call sendFeedback when detailed feedback is submitted', () => {
+    fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
+        .nativeElement.click();  // Click up
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('.feedback-details-container')))
+        .toBeTruthy();
+
+    // Fill in feedback
+    const textarea =
+        fixture.debugElement.query(By.css('textarea')).nativeElement as
+        HTMLTextAreaElement;
+    textarea.value = 'test comment';
+    textarea.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
     fixture.debugElement.queryAll(By.css('.actions button'))[1]
         .nativeElement.click();  // Submit button
     fixture.detectChanges();
 
-    expect(mockFeedbackService.sendFeedback).toHaveBeenCalledTimes(1);
-    // Dialog stays open so the user can fix the input and resubmit.
+    expect(mockFeedbackService.sendFeedback)
+        .toHaveBeenCalledWith('test-session', 'test-event', {
+          direction: 'up',
+          reasons: [],
+          comment: 'test comment',
+        });
     expect(fixture.debugElement.query(By.css('.feedback-details-container')))
-        .toBeTruthy();
-    // Buttons re-enabled so retry is possible.
-    expect(
-        fixture.debugElement.queryAll(By.css('.actions button'))[1]
-            .nativeElement.disabled,
-        )
-        .toBeFalse();
+        .toBeFalsy();
+    expect(fixture.debugElement
+               .queryAll(By.css('.feedback-buttons button mat-icon'))[0]
+               .nativeElement.textContent)
+        .toContain('thumb_up_filled');
   });
 
   it('should allow submitting negative feedback without details', () => {
@@ -289,13 +230,17 @@ describe('MessageFeedbackComponent', () => {
         .toBeFalsy();
   });
 
-  it('should hide panel and not call sendFeedback when cancelled', () => {
+  it('should hide panel when detailed feedback is cancelled', () => {
     fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
         .nativeElement.click();
     fixture.detectChanges();
 
     expect(fixture.debugElement.query(By.css('.feedback-details-container')))
         .toBeTruthy();
+    expect(mockFeedbackService.sendFeedback)
+        .toHaveBeenCalledWith(
+            'test-session', 'test-event', {direction: 'down'});
+    mockFeedbackService.sendFeedback.calls.reset();
 
     fixture.debugElement.queryAll(By.css('.actions button'))[0]
         .nativeElement.click();  // Cancel button
@@ -303,7 +248,6 @@ describe('MessageFeedbackComponent', () => {
 
     expect(fixture.debugElement.query(By.css('.feedback-details-container')))
         .toBeFalsy();
-    // No write should happen on either the thumb click or the cancel click.
     expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
   });
 
@@ -412,48 +356,33 @@ describe('MessageFeedbackComponent', () => {
         .toBeTrue();
   });
 
-  it('should disable feedback and dialog buttons while sendFeedback is in flight',
-     () => {
-       mockFeedbackService.sendFeedback.and.returnValue(NEVER);
-       fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
-           .nativeElement.click();  // Click up: opens dialog, no RPC.
-       fixture.detectChanges();
-       expect(mockFeedbackService.sendFeedback).not.toHaveBeenCalled();
+  it('should disable feedback buttons when submitting feedback', () => {
+    mockFeedbackService.sendFeedback.and.returnValues(of(undefined), NEVER);
+    fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
+        .nativeElement.click();  // Click up
+    fixture.detectChanges();
 
-       fixture.debugElement.queryAll(By.css('.actions button'))[1]
-           .nativeElement.click();  // Submit button: fires RPC.
-       fixture.detectChanges();
+    fixture.debugElement.queryAll(By.css('.actions button'))[1]
+        .nativeElement.click();  // Submit button
+    fixture.detectChanges();
 
-       expect(mockFeedbackService.sendFeedback)
-           .toHaveBeenCalledWith('test-session', 'test-event', {
-             direction: 'up',
-             reasons: [],
-             comment: '',
-           });
-       expect(mockFeedbackService.sendFeedback.calls.count()).toBe(1);
-       expect(
-           fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
-               .nativeElement.disabled,
-           )
-           .toBeTrue();
-       expect(
-           fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
-               .nativeElement.disabled,
-           )
-           .toBeTrue();
-       // Submit and Cancel must also be disabled to prevent the user from
-       // double-submitting and racing CreateFeedback against itself.
-       expect(
-           fixture.debugElement.queryAll(By.css('.actions button'))[0]
-               .nativeElement.disabled,
-           )
-           .toBeTrue();
-       expect(
-           fixture.debugElement.queryAll(By.css('.actions button'))[1]
-               .nativeElement.disabled,
-           )
-           .toBeTrue();
-     });
+    expect(mockFeedbackService.sendFeedback)
+        .toHaveBeenCalledWith('test-session', 'test-event', {
+          direction: 'up',
+          reasons: [],
+          comment: '',
+        });
+    expect(
+        fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]
+            .nativeElement.disabled,
+        )
+        .toBeTrue();
+    expect(
+        fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[1]
+            .nativeElement.disabled,
+        )
+        .toBeTrue();
+  });
 
   it('should show positive reasons when "up" is selected', () => {
     fixture.debugElement.queryAll(By.css('.feedback-buttons button'))[0]

--- a/src/app/components/session-tab/session-tab.component.spec.ts
+++ b/src/app/components/session-tab/session-tab.component.spec.ts
@@ -281,7 +281,9 @@ describe('SessionTabComponent', () => {
     });
   });
 
-  describe('when getting a session', () => {
+  // Skipped: getSession was refactored to only emit sessionSelected event
+  // Session loading and lazy loading are now handled by the parent component
+  xdescribe('when getting a session', () => {
     beforeEach(() => {
       spyOn(component.sessionSelected, 'emit');
     });
@@ -295,13 +297,7 @@ describe('SessionTabComponent', () => {
         'emits sessionSelected with default values for partial data', () => {
           sessionService.getSessionResponse.next({id: 'session1'} as Session);
           component.getSession('session1');
-          expect(component.sessionSelected.emit).toHaveBeenCalledWith({
-            id: 'session1',
-            appName: '',
-            userId: '',
-            state: {},
-            events: [],
-          } as Session);
+          expect(component.sessionSelected.emit).toHaveBeenCalledWith('session1');
         });
 
     describe('when getting a session is successful', () => {
@@ -373,7 +369,9 @@ describe('SessionTabComponent', () => {
     });
   });
 
-  describe('when reloading a session', () => {
+  // Skipped: reloadSession was refactored to only emit sessionReloaded event
+  // Session loading and lazy loading are now handled by the parent component
+  xdescribe('when reloading a session', () => {
     beforeEach(() => {
       spyOn(component.sessionReloaded, 'emit');
     });

--- a/src/app/components/side-panel/side-panel.component.spec.ts
+++ b/src/app/components/side-panel/side-panel.component.spec.ts
@@ -17,11 +17,9 @@
 
 import {Location} from '@angular/common';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatOption} from '@angular/material/core';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import {MatPaginator} from '@angular/material/paginator';
-import {MatSelectChange} from '@angular/material/select';
-import {MatSnackBar} from '@angular/material/snack-bar';
+import { SnackbarService } from '../../core/services/snackbar.service';
 import {MatTab, MatTabGroup} from '@angular/material/tabs';
 import {By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -68,15 +66,12 @@ import {SidePanelComponent} from './side-panel.component';
 const TABS_CONTAINER_SELECTOR = By.css('.tabs-container');
 const DETAILS_PANEL_SELECTOR = By.css('.details-panel-container');
 const TAB_HEADERS_SELECTOR = By.css('[role="tab"]');
-const SESSION_TAB_SELECTOR = By.css('app-session-tab');
 const EVAL_TAB_SELECTOR = By.css('app-eval-tab');
 const DETAILS_PANEL_CLOSE_BUTTON_SELECTOR =
     By.css('.details-panel-container mat-icon');
 const EVENT_GRAPH_SELECTOR = By.css('.event-graph-container div');
-const APP_SELECT_SELECTOR = By.css('.app-select');
 
-const SESSIONS_TAB_INDEX = 3;
-const EVAL_TAB_INDEX = 4;
+const EVAL_TAB_INDEX = 3;
 
 describe('SidePanelComponent', () => {
   let component: SidePanelComponent;
@@ -94,7 +89,7 @@ describe('SidePanelComponent', () => {
   let mockUiStateService: MockUiStateService;
   let mockFeatureFlagService: MockFeatureFlagService;
   let mockDialog: jasmine.SpyObj<MatDialog>;
-  let mockSnackBar: jasmine.SpyObj<MatSnackBar>;
+  let mockSnackBar: jasmine.SpyObj<SnackbarService>;
   let mockActivatedRoute: Partial<ActivatedRoute>;
   let mockLocation: jasmine.SpyObj<Location>;
 
@@ -158,7 +153,7 @@ describe('SidePanelComponent', () => {
     mockUiStateService = new MockUiStateService();
     mockFeatureFlagService = new MockFeatureFlagService();
     mockDialog = jasmine.createSpyObj('MatDialog', ['open']);
-    mockSnackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+    mockSnackBar = jasmine.createSpyObj('SnackbarService', ['open']);
     mockLocation = jasmine.createSpyObj('Location', ['replaceState']);
     mockActivatedRoute = {
       snapshot: {
@@ -179,7 +174,6 @@ describe('SidePanelComponent', () => {
     mockFeatureFlagService.isApplicationSelectorEnabledResponse.next(true);
     mockFeatureFlagService.isTraceEnabledResponse.next(true);
     mockFeatureFlagService.isArtifactsTabEnabledResponse.next(true);
-
     mockFeatureFlagService.isEvalEnabledResponse.next(true);
     mockFeatureFlagService.isTokenStreamingEnabled.and.returnValue(of(true));
     mockFeatureFlagService.isMessageFileUploadEnabled.and.returnValue(of(true));
@@ -204,7 +198,7 @@ describe('SidePanelComponent', () => {
         {provide: UI_STATE_SERVICE, useValue: mockUiStateService},
         {provide: FEATURE_FLAG_SERVICE, useValue: mockFeatureFlagService},
         {provide: MatDialog, useValue: mockDialog},
-        {provide: MatSnackBar, useValue: mockSnackBar},
+        {provide: SnackbarService, useValue: mockSnackBar},
         provideRouter([]),
         {provide: ActivatedRoute, useValue: mockActivatedRoute},
         {provide: Location, useValue: mockLocation},
@@ -232,8 +226,6 @@ describe('SidePanelComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-
 
   describe('Tab hiding', () => {
     it('should hide Trace tab when isTraceEnabled is false', () => {
@@ -271,8 +263,6 @@ describe('SidePanelComponent', () => {
       );
       expect(evalLabel).toBeUndefined();
     });
-
-
   });
 
   describe('Rendering', () => {
@@ -303,15 +293,6 @@ describe('SidePanelComponent', () => {
       });
     });
 
-    describe('when selectedEvent is defined', () => {
-      beforeEach(() => {
-        fixture.componentRef.setInput('selectedEvent', {id: 'event1'});
-        fixture.detectChanges();
-      });
-      it('shows details panel', () => {
-        expect(fixture.debugElement.query(DETAILS_PANEL_SELECTOR)).toBeTruthy();
-      });
-    });
   });
 
   describe('Tabs', () => {
@@ -328,8 +309,6 @@ describe('SidePanelComponent', () => {
       });
     });
 
-
-
     describe('Eval tab', () => {
       describe('Interactions', () => {
         beforeEach(async () => {
@@ -337,10 +316,12 @@ describe('SidePanelComponent', () => {
         });
 
         describe('when app-eval-tab emits evalCaseSelected', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
+            await fixture.whenStable();
+            fixture.detectChanges();
             spyOn(component.evalCaseSelected, 'emit');
             const evalTab = fixture.debugElement.query(EVAL_TAB_SELECTOR);
-            evalTab.componentInstance.evalCaseSelected.emit({
+            evalTab!.componentInstance.evalCaseSelected.emit({
               evalId: 'eval1',
             } as unknown as EvalCase);
             fixture.detectChanges();
@@ -353,10 +334,12 @@ describe('SidePanelComponent', () => {
         });
 
         describe('when app-eval-tab emits evalSetIdSelected', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
+            await fixture.whenStable();
+            fixture.detectChanges();
             spyOn(component.evalSetIdSelected, 'emit');
             const evalTab = fixture.debugElement.query(EVAL_TAB_SELECTOR);
-            evalTab.componentInstance.evalSetIdSelected.emit('set1');
+            evalTab!.componentInstance.evalSetIdSelected.emit('set1');
             fixture.detectChanges();
           });
           it('emits evalSetIdSelected', () => {
@@ -366,10 +349,12 @@ describe('SidePanelComponent', () => {
         });
 
         describe('when app-eval-tab emits shouldReturnToSession', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
+            await fixture.whenStable();
+            fixture.detectChanges();
             spyOn(component.returnToSession, 'emit');
             const evalTab = fixture.debugElement.query(EVAL_TAB_SELECTOR);
-            evalTab.componentInstance.shouldReturnToSession.emit(true);
+            evalTab!.componentInstance.shouldReturnToSession.emit(true);
             fixture.detectChanges();
           });
           it('emits returnToSession', () => {
@@ -378,10 +363,12 @@ describe('SidePanelComponent', () => {
         });
 
         describe('when app-eval-tab emits evalNotInstalledMsg', () => {
-          beforeEach(() => {
+          beforeEach(async () => {
+            await fixture.whenStable();
+            fixture.detectChanges();
             spyOn(component.evalNotInstalled, 'emit');
             const evalTab = fixture.debugElement.query(EVAL_TAB_SELECTOR);
-            evalTab.componentInstance.evalNotInstalledMsg.emit('error');
+            evalTab!.componentInstance.evalNotInstalledMsg.emit('error');
             fixture.detectChanges();
           });
           it('emits evalNotInstalled', () => {
@@ -399,18 +386,6 @@ describe('SidePanelComponent', () => {
       fixture.detectChanges();
     });
 
-    describe('when close button is clicked', () => {
-      beforeEach(() => {
-        spyOn(component.closeSelectedEvent, 'emit');
-        const closeButton =
-            fixture.debugElement.query(DETAILS_PANEL_CLOSE_BUTTON_SELECTOR);
-        closeButton.nativeElement.click();
-      });
-      it('emits closeSelectedEvent', () => {
-        expect(component.closeSelectedEvent.emit).toHaveBeenCalled();
-      });
-    });
-
     describe('when paginator page is changed', () => {
       beforeEach(() => {
         spyOn(component.page, 'emit');
@@ -425,20 +400,6 @@ describe('SidePanelComponent', () => {
       });
     });
 
-    describe('when event graph is clicked', () => {
-      beforeEach(async () => {
-        fixture.componentRef.setInput('renderedEventGraph', '<div>graph</div>');
-        fixture.detectChanges();
-        await fixture.whenStable();
-        fixture.detectChanges();
-        spyOn(component.openImageDialog, 'emit');
-        const graphContainer = fixture.debugElement.query(EVENT_GRAPH_SELECTOR);
-        graphContainer.nativeElement.click();
-      });
-      it('emits openImageDialog', () => {
-        expect(component.openImageDialog.emit).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('Loading state', () => {
@@ -457,12 +418,6 @@ describe('SidePanelComponent', () => {
       it('hides tabs container', () => {
         expect(fixture.debugElement.query(TABS_CONTAINER_SELECTOR)!.nativeElement.hidden).toBeTrue();
       });
-
-      it('hides details panel', () => {
-        fixture.componentRef.setInput('selectedEvent', {id: 'event1'});
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(DETAILS_PANEL_SELECTOR)!.nativeElement.hidden).toBeTrue();
-      });
     });
 
     describe('when session is not loading', () => {
@@ -480,12 +435,6 @@ describe('SidePanelComponent', () => {
       it('shows tabs container', () => {
         expect(fixture.debugElement.query(TABS_CONTAINER_SELECTOR)!.nativeElement.hidden)
             .toBeFalse();
-      });
-
-      it('shows details panel when event is selected', () => {
-        fixture.componentRef.setInput('selectedEvent', {id: 'event1'});
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(DETAILS_PANEL_SELECTOR)!.nativeElement.hidden).toBeFalse();
       });
     });
   });

--- a/src/app/components/system-instruction-diff-dialog/system-instruction-diff-dialog.component.spec.ts
+++ b/src/app/components/system-instruction-diff-dialog/system-instruction-diff-dialog.component.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../testing/utils';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -36,7 +34,6 @@ describe('SystemInstructionDiffDialogComponent', () => {
   beforeEach(async () => {
     mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
 
-    initTestBed();  // required for 1p compat
     await TestBed.configureTestingModule({
       imports: [SystemInstructionDiffDialogComponent, NoopAnimationsModule],
       providers: [

--- a/src/app/components/trace-tab/trace-tab.component.spec.ts
+++ b/src/app/components/trace-tab/trace-tab.component.spec.ts
@@ -91,4 +91,77 @@ describe('TraceTabComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should display no invocations if traceData is empty', async () => {
+    const expansionPanels = await loader.getAllHarnesses(
+        MatExpansionPanelHarness,
+    );
+    expect(expansionPanels.length).toBe(0);
+  });
+
+  // Skipped: mat-expansion-panel UI removed in UI refactor
+  xdescribe('with trace data', () => {
+    const MOCK_TRACE_DATA_WITH_MULTIPLE_TRACES: Span[] = [
+      ...MOCK_TRACE_DATA,
+      makeSpan({
+        name: 'agent.act-2',
+        start_time: 1733084700000000000,
+        end_time: 1733084760000000000,
+        span_id: 'span-10',
+        trace_id: 'trace-2',
+        attributes: {
+          'event_id': 10,
+          'gcp.vertex.agent.invocation_id': 'invoc-2',
+          'gcp.vertex.agent.llm_request':
+              '{"contents":[{"role":"user","parts":[{"text":"Another user message"}]}]}',
+        },
+      }),
+    ];
+
+    beforeEach(async () => {
+      fixture.componentRef.setInput(
+          'traceData',
+          MOCK_TRACE_DATA_WITH_MULTIPLE_TRACES,
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    it('should group traces by trace_id and display as expansion panels',
+       async () => {
+         const expansionPanels = await loader.getAllHarnesses(
+             MatExpansionPanelHarness,
+         );
+         expect(expansionPanels.length).toBe(2);
+       });
+
+    it('should display user message as panel title', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const expansionPanels = await loader.getAllHarnesses(
+          MatExpansionPanelHarness,
+      );
+      expect(expansionPanels.length).toBe(2);
+      expect(await expansionPanels[0].getTitle())
+          .toBe(
+              'I need help with my project.',
+          );
+      expect(await expansionPanels[1].getTitle()).toBe('Another user message');
+    });
+
+    it('should pass correct data to trace-tree component', async () => {
+      fixture.detectChanges();
+      await fixture.whenStable();
+      const expansionPanels = await loader.getAllHarnesses(
+          MatExpansionPanelHarness,
+      );
+      expect(expansionPanels.length).toBeGreaterThan(0);
+      await expansionPanels[0].expand();
+      fixture.detectChanges();
+
+      const traceTree = fixture.nativeElement.querySelector('app-trace-tree');
+      expect(traceTree).toBeTruthy();
+      // Further inspection of trace-tree inputs would require a harness or
+      // mocking TraceTreeComponent
+    });
+  });
 });

--- a/src/app/components/trace-tab/trace-tree/trace-tree.component.spec.ts
+++ b/src/app/components/trace-tab/trace-tree/trace-tree.component.spec.ts
@@ -28,7 +28,6 @@ describe('TraceTreeComponent', () => {
     const traceService = {
       ...jasmine.createSpyObj<TraceService>([
         'selectedRow',
-        'setHoveredMessages',
       ]),
       selectedTraceRow$: of(undefined),
       eventData$: of(new Map<string, any>()),

--- a/src/app/components/view-image-dialog/view-image-dialog.component.spec.ts
+++ b/src/app/components/view-image-dialog/view-image-dialog.component.spec.ts
@@ -97,4 +97,37 @@ describe('ViewImageDialogComponent', () => {
     expect(placeholder.nativeElement.textContent)
         .toContain('No image data provided.');
   });
+
+  it('should display image title if url is provided', () => {
+    const testData = 'data:image/png;base64,xyz';
+    const testUrl = 'http://example.com';
+    mockDialogData.imageData = testData;
+    mockDialogData.images = [testData];
+    mockDialogData.urls = [testUrl];
+    mockSafeValuesService.bypassSecurityTrustUrl.and.returnValue(testData);
+
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    const titleElement = fixture.debugElement.query(By.css('.image-title'));
+    expect(titleElement).not.toBeNull();
+    expect(titleElement.nativeElement.textContent).toContain(testUrl);
+  });
+  it('should display highlight circle if coordinate is provided', () => {
+    const testData = 'data:image/png;base64,xyz';
+    mockDialogData.imageData = testData;
+    mockDialogData.images = [testData];
+    mockDialogData.coordinates = [{x: 500, y: 500}];
+    mockSafeValuesService.bypassSecurityTrustUrl.and.returnValue(testData);
+
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    const highlightElement = fixture.debugElement.query(By.css('.highlight-circle'));
+    expect(highlightElement).not.toBeNull();
+    
+    const style = highlightElement.nativeElement.style;
+    expect(style.left).toBe('50%');
+    expect(style.top).toBe('50%');
+  });
 });

--- a/src/app/components/workflow-graph-tooltip/workflow-graph-tooltip.component.ts
+++ b/src/app/components/workflow-graph-tooltip/workflow-graph-tooltip.component.ts
@@ -274,7 +274,7 @@ export class WorkflowGraphTooltipComponent implements OnInit {
               color: isActive ? '#42A5F5' : 'rgba(138, 180, 248, 0.8)',
             },
           },
-        } as unknown as Edge);
+        });
       }
     });
   }
@@ -338,7 +338,7 @@ export class WorkflowGraphTooltipComponent implements OnInit {
               color: isActive ? '#42A5F5' : 'rgba(138, 180, 248, 0.8)',
             },
           },
-        } as unknown as Edge);
+        });
       }
     });
 

--- a/src/app/core/constants/a2ui-theme.ts
+++ b/src/app/core/constants/a2ui-theme.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import {Styles} from '@a2ui/lit/0.8';
-import {Types} from '@a2ui/lit/0.8';
+import { Types, Styles } from '@a2ui/lit/0.8';
 
 /** Elements */
 

--- a/src/app/core/models/UiEvent.ts
+++ b/src/app/core/models/UiEvent.ts
@@ -16,7 +16,7 @@
  */
 
 import { ExecutableCode, CodeExecutionResult, FunctionCall, FunctionResponse, Event } from './types';
-import { MediaType } from './types';
+import { MediaType } from '../../components/artifact-tab/artifact-tab.component';
 
 export class UiEvent {
   role!: 'user' | 'bot' | string;

--- a/src/app/core/models/testing/computer-use.spec.ts
+++ b/src/app/core/models/testing/computer-use.spec.ts
@@ -63,6 +63,16 @@ describe('ComputerUse', () => {
       expect(isVisibleComputerUseClick(call)).toBeTrue();
     });
 
+    it('should return true for scroll document tool without coordinates', () => {
+      const call = {
+        name: ComputerTool.SCROLL_DOCUMENT,
+        args: {
+          direction: 'down'
+        }
+      };
+      expect(isVisibleComputerUseClick(call)).toBeTrue();
+    });
+
     it('should return false for non-visual actions in computer tool', () => {
       const call = {
         name: ComputerTool.COMPUTER,

--- a/src/app/core/models/trace.spec.ts
+++ b/src/app/core/models/trace.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../testing/utils';
 import {
   FallbackSpan,
   GenerateContentSpan,

--- a/src/app/core/models/trace/ExperimentalSemconv.spec.ts
+++ b/src/app/core/models/trace/ExperimentalSemconv.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../../testing/utils';
 import {
   CompletionDetailsLogValidator,
   GEN_AI_COMPLETION_DETAILS_EVENT,

--- a/src/app/core/models/trace/StableSemconv.spec.ts
+++ b/src/app/core/models/trace/StableSemconv.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../../testing/utils';
 import {
   GEN_AI_CHOICE_EVENT,
   GEN_AI_SYSTEM_MESSAGE_EVENT,

--- a/src/app/core/models/types.ts
+++ b/src/app/core/models/types.ts
@@ -147,11 +147,3 @@ export interface ComputerUsePayload {
   image?: {data: string; mimetype?: string;};
   url?: string;
 }
-
-export enum MediaType {
-  IMAGE = 'image',
-  AUDIO = 'audio',
-  VIDEO = 'video',
-  TEXT = 'text',
-  UNSPECIFIED = 'unspecified',
-}

--- a/src/app/core/services/analytics.service.spec.ts
+++ b/src/app/core/services/analytics.service.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../testing/utils';
 import { TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { AnalyticsService, DEFAULT_GA_MEASUREMENT_ID } from './analytics.service';
@@ -33,7 +31,6 @@ describe('AnalyticsService', () => {
       telemetryEnabled: signal(false),
     };
 
-    initTestBed();  // required for 1p compat
     TestBed.configureTestingModule({
       providers: [
         AnalyticsService,

--- a/src/app/core/services/analytics.service.ts
+++ b/src/app/core/services/analytics.service.ts
@@ -17,8 +17,6 @@
 
 import { inject, Injectable, effect } from '@angular/core';
 import { TelemetryService } from './telemetry.service';
-import {setScriptSrc} from 'safevalues/dom';
-import {trustedResourceUrl} from 'safevalues';
 
 declare global {
   interface Window {
@@ -68,7 +66,7 @@ export class AnalyticsService {
       // Load GA4 script
       const script = document.createElement('script');
       script.async = true;
-      setScriptSrc(script, trustedResourceUrl`https://www.googletagmanager.com/gtag/js?id=${this.measurementId}`);
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${this.measurementId}`;
       document.head.appendChild(script);
 
       window.gtag('js', new Date());

--- a/src/app/core/services/feature-flag.service.spec.ts
+++ b/src/app/core/services/feature-flag.service.spec.ts
@@ -58,12 +58,12 @@ describe('FeatureFlagService', () => {
          expect(isEnabled).toBeTrue();
        });
 
-    it('should return false if \'import_session\' query param is not \'true\'',
+    it('should return true (always enabled in this implementation)',
        async () => {
          activatedRoute.queryParams.next({});
          const isEnabled =
              await firstValueFrom(service.isImportSessionEnabled());
-         expect(isEnabled).toBeFalse();
+         expect(isEnabled).toBeTrue();
        });
   });
 
@@ -117,6 +117,4 @@ describe('FeatureFlagService', () => {
       expect(isEnabled).toBeTrue();
     });
   });
-
-
 });

--- a/src/app/core/services/session.service.spec.ts
+++ b/src/app/core/services/session.service.spec.ts
@@ -139,9 +139,8 @@ describe('SessionService', () => {
              API_SERVER_BASE_URL + SESSIONS_PATH,
          );
          expect(req.request.method).toEqual(METHOD_POST);
+         // appName and userId are now in the URL, not the body
          expect(req.request.body).toEqual({
-           appName: APP_NAME,
-           userId: USER_ID,
            events,
          });
          req.flush({});

--- a/src/app/core/services/snackbar.service.spec.ts
+++ b/src/app/core/services/snackbar.service.spec.ts
@@ -1,0 +1,39 @@
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+import {initTestBed} from '../../testing/utils';
+import { TestBed } from '@angular/core/testing';
+import { SnackbarService } from './snackbar.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+describe('SnackbarService', () => {
+  let service: SnackbarService;
+  let mockMatSnackBar: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    mockMatSnackBar = jasmine.createSpyObj('MatSnackBar', ['open']);
+
+    initTestBed();  // required for 1p compat
+    TestBed.configureTestingModule({
+      providers: [
+        SnackbarService,
+        { provide: MatSnackBar, useValue: mockMatSnackBar }
+      ]
+    });
+    service = TestBed.inject(SnackbarService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should truncate long messages', () => {
+    const longMessage = 'a'.repeat(300);
+    service.open(longMessage);
+    expect(mockMatSnackBar.open).toHaveBeenCalledWith('a'.repeat(250) + '...', undefined, undefined);
+  });
+
+  it('should not truncate short messages', () => {
+    const shortMessage = 'short message';
+    service.open(shortMessage);
+    expect(mockMatSnackBar.open).toHaveBeenCalledWith(shortMessage, undefined, undefined);
+  });
+});

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -18,8 +18,6 @@
 import { Injectable, signal, effect } from '@angular/core';
 import { ThemeServiceInterface, Theme } from './interfaces/theme';
 
-import {trustedResourceUrl} from 'safevalues';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -67,18 +65,15 @@ export class ThemeService implements ThemeServiceInterface {
   }
 
   private updatePrismTheme(theme: Theme): void {
-    const linkId = "prism-theme-style";
+    const linkId = 'prism-theme-style';
     let linkElement = document.getElementById(linkId) as HTMLLinkElement;
     if (!linkElement) {
-      linkElement = document.createElement("link");
+      linkElement = document.createElement('link');
       linkElement.id = linkId;
+      linkElement.rel = 'stylesheet';
       document.head.appendChild(linkElement);
     }
-    setLinkHrefAndRel(
-      linkElement,
-      theme === "light" ? trustedResourceUrl`prism-light.css` : trustedResourceUrl`prism-dark.css`,
-      "stylesheet",
-    );
+    linkElement.href = theme === 'light' ? 'prism-light.css' : 'prism-dark.css';
   }
 
   toggleTheme(): void {

--- a/src/app/core/services/trace.service.spec.ts
+++ b/src/app/core/services/trace.service.spec.ts
@@ -75,8 +75,6 @@ describe('TraceService', () => {
     });
   });
 
-
-
   describe('resetTraceService', () => {
     it('should reset eventData to undefined', async () => {
       service.setEventData(new Map<string, any>());
@@ -91,7 +89,5 @@ describe('TraceService', () => {
       const messages = await firstValueFrom(service.messages$);
       expect(messages).toEqual([]);
     });
-
-
   });
 });

--- a/src/app/core/utils/audio.spec.ts
+++ b/src/app/core/utils/audio.spec.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
-import {initTestBed} from '../../testing/utils';
 import {base64ToArrayBuffer, pcmChunksToWavBase64} from './audio';
 
 /** Decodes base64 -> Uint8Array for assertions. */

--- a/src/app/directives/resizable-drawer.directive.spec.ts
+++ b/src/app/directives/resizable-drawer.directive.spec.ts
@@ -23,8 +23,8 @@ import {ResizableDrawerDirective} from './resizable-drawer.directive';
 
 // Directive constants
 const SIDE_DRAWER_WIDTH_VAR = '--side-drawer-width';
-const INITIAL_WIDTH = 570;
-const MIN_WIDTH = 310;
+const INITIAL_WIDTH = 480;
+const MIN_WIDTH = 360;
 
 // Test constants
 const MOCKED_WINDOW_WIDTH = 2000;
@@ -91,7 +91,7 @@ describe('ResizableDrawerDirective', () => {
     body.classList.remove('resizing');
   });
 
-  it('should set initial width to 570px after view init', () => {
+  it('should set initial width to 480px after view init', () => {
     // Assert
     expect(directiveElement.style.width).toBe('var(--side-drawer-width)');
     expect(getDrawerWidth()).toBe(INITIAL_WIDTH);

--- a/src/assets/audio-processor.js
+++ b/src/assets/audio-processor.js
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The last 13 commits left the public repo unbuildable: an internal sync was applied inconsistently, leaving three components importing MarkdownComponent while their bodies still inject MARKDOWN_COMPONENT, edit-json-dialog importing a json-editor.component.google file that has no public counterpart, and theme.service calling setLinkHrefAndRel without importing it. Eleven compile errors in total, plus nine spec files dropped and the mermaid dependency removed while still imported.

Rather than patch each break in place, reset the tree to the last known good commit so the sync can be redone cleanly. The safevalues hardening in analytics.service and theme.service is worth re-landing separately once the import errors are sorted out.