### PR TITLE
feat(live): add support for voice activity start and end events

### DIFF
--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -1985,6 +1985,17 @@ describe('ChatComponent', () => {
         };
         expect((component as any).isEmptyMetadataEvent(event)).toBeFalse();
       });
+
+      it('returns false when a marker event signals voiceActivity', () => {
+        const event = {
+          id: 'vad-1',
+          author: 'agent',
+          usageMetadata: {totalTokenCount: 1},
+          voiceActivity: {voiceActivityType: 'ACTIVITY_START'},
+          actions: {...EMPTY_ACTIONS},
+        };
+        expect((component as any).isEmptyMetadataEvent(event)).toBeFalse();
+      });
     });
 
     describe('actionsAreEmpty', () => {

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -1407,6 +1407,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
       && apiEvent.output === undefined
       && apiEvent.inputTranscription === undefined
       && apiEvent.outputTranscription === undefined
+      && apiEvent.voiceActivity === undefined
       && !apiEvent.errorMessage
       && !apiEvent.errorCode
       && !apiEvent.systemInstructionChanged

--- a/src/app/components/event-content/event-content.component.html
+++ b/src/app/components/event-content/event-content.component.html
@@ -44,6 +44,22 @@
       [tooltipTitle]="'Turn Complete'"
     ></app-hover-info-button>
     }
+    @if (uiEvent.event.voiceActivity?.voiceActivityType === 'ACTIVITY_START') {
+    <app-hover-info-button
+      [icon]="'mic'"
+      [text]="'Voice Activity Start'"
+      [tooltipContent]="uiEvent.event.voiceActivity?.audioOffset ? 'Started at ' + uiEvent.event.voiceActivity!.audioOffset : 'Started'"
+      [tooltipTitle]="'Voice Activity Start'"
+    ></app-hover-info-button>
+    }
+    @if (uiEvent.event.voiceActivity?.voiceActivityType === 'ACTIVITY_END') {
+    <app-hover-info-button
+      [icon]="'mic_off'"
+      [text]="'Voice Activity End'"
+      [tooltipContent]="uiEvent.event.voiceActivity?.audioOffset ? 'Ended at ' + uiEvent.event.voiceActivity!.audioOffset : 'Ended'"
+      [tooltipTitle]="'Voice Activity End'"
+    ></app-hover-info-button>
+    }
     @if (uiEvent.event.interrupted) {
     <app-hover-info-button
       [icon]="'report'"

--- a/src/app/components/event-content/event-content.component.spec.ts
+++ b/src/app/components/event-content/event-content.component.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatDialog} from '@angular/material/dialog';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+
+import {UiEvent} from '../../core/models/UiEvent';
+import {initTestBed} from '../../testing/utils';
+import {ChatPanelMessagesInjectionToken, CHAT_PANEL_MESSAGES} from '../chat-panel/chat-panel.component.i18n';
+import {EventContentComponent} from './event-content.component';
+
+describe('EventContentComponent', () => {
+  let component: EventContentComponent;
+  let fixture: ComponentFixture<EventContentComponent>;
+
+  beforeEach(async () => {
+    initTestBed();
+
+    await TestBed.configureTestingModule({
+      imports: [EventContentComponent, NoopAnimationsModule],
+      providers: [
+        {
+          provide: ChatPanelMessagesInjectionToken,
+          useValue: CHAT_PANEL_MESSAGES,
+        },
+        {
+          provide: MatDialog,
+          useValue: {open: () => ({afterClosed: () => ({subscribe: () => {}})})},
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EventContentComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('Voice Activity Events', () => {
+    it('renders Voice Activity Start chip with mic icon and tooltip', () => {
+      component.uiEvent = new UiEvent({
+        role: 'bot',
+        event: {
+          id: 'vad-start-1',
+          voiceActivity: {
+            voiceActivityType: 'ACTIVITY_START',
+            audioOffset: '1.5s',
+          },
+        } as any,
+      });
+      component.index = 0;
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.queryAll(By.css('app-hover-info-button'));
+      const startBtn = buttons.find(b => b.componentInstance.text === 'Voice Activity Start');
+      expect(startBtn).toBeTruthy();
+      expect(startBtn?.componentInstance.icon).toBe('mic');
+      expect(startBtn?.componentInstance.tooltipContent).toBe('Started at 1.5s');
+    });
+
+    it('renders Voice Activity End chip with mic_off icon and tooltip', () => {
+      component.uiEvent = new UiEvent({
+        role: 'bot',
+        event: {
+          id: 'vad-end-1',
+          voiceActivity: {
+            voiceActivityType: 'ACTIVITY_END',
+            audioOffset: '3.2s',
+          },
+        } as any,
+      });
+      component.index = 1;
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.queryAll(By.css('app-hover-info-button'));
+      const endBtn = buttons.find(b => b.componentInstance.text === 'Voice Activity End');
+      expect(endBtn).toBeTruthy();
+      expect(endBtn?.componentInstance.icon).toBe('mic_off');
+      expect(endBtn?.componentInstance.tooltipContent).toBe('Ended at 3.2s');
+    });
+
+    it('renders default tooltip when audio offset is missing', () => {
+      component.uiEvent = new UiEvent({
+        role: 'bot',
+        event: {
+          id: 'vad-start-2',
+          voiceActivity: {
+            voiceActivityType: 'ACTIVITY_START',
+          },
+        } as any,
+      });
+      component.index = 0;
+      fixture.detectChanges();
+
+      const buttons = fixture.debugElement.queryAll(By.css('app-hover-info-button'));
+      const startBtn = buttons.find(b => b.componentInstance.text === 'Voice Activity Start');
+      expect(startBtn?.componentInstance.tooltipContent).toBe('Started');
+    });
+  });
+});

--- a/src/app/core/models/types.ts
+++ b/src/app/core/models/types.ts
@@ -71,12 +71,18 @@ export declare interface LlmRequest {
   contents: GenAiContent[];
 }
 
+export declare interface VoiceActivity {
+  voiceActivityType?: string;
+  audioOffset?: string;
+}
+
 export declare interface LlmResponse {
   content: GenAiContent;
   error?: string;
   errorMessage?: string;
   errorCode?: string;
   longRunningToolIds?: string[];
+  voiceActivity?: VoiceActivity;
 }
 
 export enum NodeStatus {


### PR DESCRIPTION
## Summary

Adds support for visualizing Voice Activity Start and Voice Activity End events in ADK Web's chat event list.

In bidirectional live sessions (e.g. Gemini Live), the server sends `voiceActivity` events (`ACTIVITY_START` and `ACTIVITY_END`) with optional audio offsets indicating when speech begins and ends in the audio stream. Previously, these events had no UI chips and rendered as empty node rows in the chat timeline.

### Changes
- **Core Types (`src/app/core/models/types.ts`)**:
  - Added `VoiceActivity` interface with properties `voiceActivityType` and `audioOffset`.
  - Added `voiceActivity?: VoiceActivity` to `LlmResponse` (inherited by `Event`).
- **Event Content Component (`src/app/components/event-content/event-content.component.html`)**:
  - Added chips for `Voice Activity Start` (icon `mic`) and `Voice Activity End` (icon `mic_off`).
  - Added concise tooltip content (e.g. `Started at 1.5s` / `Ended at 3.2s`, or `Started` / `Ended`).
- **Chat Component (`src/app/components/chat/chat.component.ts`)**:
  - Ensured `isEmptyMetadataEvent` does not drop events carrying `voiceActivity`.
- **Tests**:
  - Added unit test in `src/app/components/chat/chat.component.spec.ts` for `isEmptyMetadataEvent`.
  - Created `src/app/components/event-content/event-content.component.spec.ts` covering Start, End, and offset fallback rendering.