### PR TITLE
feat: total cached-content and reasoning tokens in session usage summary

### DIFF
--- a/src/app/components/event-tab/event-tab.component.html
+++ b/src/app/components/event-tab/event-tab.component.html
@@ -245,10 +245,22 @@
             <td>Total Prompt Tokens</td>
             <td class="numeric-cell">{{ sessionUsageMetadata()['Prompt Tokens'] | number }}</td>
           </tr>
+          @if (sessionUsageMetadata()['Cached Content Tokens'] > 0) {
+          <tr>
+            <td>Total Cached Content Tokens</td>
+            <td class="numeric-cell">{{ sessionUsageMetadata()['Cached Content Tokens'] | number }}</td>
+          </tr>
+          }
           <tr>
             <td>Total Candidates Tokens</td>
             <td class="numeric-cell">{{ sessionUsageMetadata()['Candidates Tokens'] | number }}</td>
           </tr>
+          @if (sessionUsageMetadata()['Thoughts Tokens'] > 0) {
+          <tr>
+            <td>Total Thoughts Tokens</td>
+            <td class="numeric-cell">{{ sessionUsageMetadata()['Thoughts Tokens'] | number }}</td>
+          </tr>
+          }
           <tr>
             <td>Total Tokens</td>
             <td class="numeric-cell">{{ sessionUsageMetadata()['Total Tokens'] | number }}</td>

--- a/src/app/components/event-tab/event-tab.component.ts
+++ b/src/app/components/event-tab/event-tab.component.ts
@@ -190,6 +190,8 @@ export class EventTabComponent {
     const allEvents = Array.from(this.eventDataMap().values());
     let totalPromptTokens = 0;
     let totalCandidatesTokens = 0;
+    let totalCachedContentTokens = 0;
+    let totalThoughtsTokens = 0;
     let totalTokens = 0;
 
     allEvents.forEach(ev => {
@@ -197,10 +199,14 @@ export class EventTabComponent {
       if (metadata) {
         const prompt = metadata.promptTokenCount ?? metadata.promptTokens ?? 0;
         const candidates = metadata.candidatesTokenCount ?? metadata.candidatesTokens ?? 0;
+        const cachedContent = metadata.cachedContentTokenCount ?? metadata.cachedContentTokens ?? 0;
+        const thoughts = metadata.thoughtsTokenCount ?? metadata.thoughtsTokens ?? 0;
         const total = metadata.totalTokenCount ?? metadata.totalTokens ?? 0;
 
         totalPromptTokens += Number(prompt);
         totalCandidatesTokens += Number(candidates);
+        totalCachedContentTokens += Number(cachedContent);
+        totalThoughtsTokens += Number(thoughts);
         totalTokens += Number(total);
       }
     });
@@ -208,6 +214,8 @@ export class EventTabComponent {
     return {
       'Prompt Tokens': totalPromptTokens,
       'Candidates Tokens': totalCandidatesTokens,
+      'Cached Content Tokens': totalCachedContentTokens,
+      'Thoughts Tokens': totalThoughtsTokens,
       'Total Tokens': totalTokens
     };
   });


### PR DESCRIPTION
## What
Adds session-level totals for **cached-content (cache-read)** and **thoughts (reasoning)** tokens to the Event tab's "Usage Summary for Session".

## Why
The per-event usage view already renders every `usageMetadata` field, but the session-level rollup only summed prompt, candidates, and total tokens. Cache-read and reasoning tokens are billed differently and are useful for cost-at-a-glance, so they belong in the session totals too.

## Changes
- `event-tab.component.ts` — extend the `sessionUsageMetadata` computed to also sum `cachedContentTokenCount` and `thoughtsTokenCount`.
- `event-tab.component.html` — add "Total Cached Content Tokens" and "Total Thoughts Tokens" rows, each shown only when its total is `> 0`, so sessions without caching/reasoning look unchanged.

## Testing
- `npm run build` passes.
- New rows appear only for sessions that used prompt caching / reasoning; other sessions are unchanged.