### PR TITLE
fix(artifacts): stop artifact blobs opening as scriptable documents

### DIFF
--- a/src/app/core/services/interfaces/safevalues.ts
+++ b/src/app/core/services/interfaces/safevalues.ts
@@ -41,6 +41,35 @@ declare interface SafeValuesServiceInterface {
 }
 
 /**
+ * MIME types a browser parses into a scriptable document.
+ *
+ * A blob URL inherits the origin of the page that created it, so opening one
+ * of these in a tab executes the content with the app's origin and a live
+ * `window.opener` handle back into the session. Artifact bytes are untrusted --
+ * an agent, a tool, or an upload produced them -- so these are handed to the
+ * browser as opaque data rather than as a document.
+ */
+const SCRIPTABLE_DOCUMENT_TYPES: ReadonlySet<string> = new Set([
+  'text/html',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'text/xml',
+  'application/xml',
+]);
+
+const OPAQUE_TYPE = 'application/octet-stream';
+
+/**
+ * The blob type to use for `mimeType`, downgraded to an opaque type when the
+ * browser would otherwise parse it as a scriptable document. Parameters
+ * (`text/html; charset=utf-8`) are stripped before comparing.
+ */
+function blobTypeFor(mimeType: string): string {
+  const essence = mimeType.split(';')[0].trim().toLowerCase();
+  return SCRIPTABLE_DOCUMENT_TYPES.has(essence) ? OPAQUE_TYPE : mimeType;
+}
+
+/**
  * Service to provide safe values for DOM manipulation.
  */
 export abstract class SafeValuesService implements SafeValuesServiceInterface {
@@ -84,7 +113,7 @@ export abstract class SafeValuesService implements SafeValuesServiceInterface {
       }
       const byteArray = new Uint8Array(byteNumbers);
 
-      const blob = new Blob([byteArray], {type: mimeType});
+      const blob = new Blob([byteArray], {type: blobTypeFor(mimeType)});
 
       const newWindow = this.openBlobUrl(blob);
       if (newWindow) {

--- a/src/app/core/services/safevalues.service.spec.ts
+++ b/src/app/core/services/safevalues.service.spec.ts
@@ -101,6 +101,45 @@ describe('SafeValuesService', () => {
       expect(blob.size).toBeGreaterThan(0);
     });
 
+    it('should not give the blob a scriptable document type', () => {
+      // A blob URL inherits the opener's origin, so a scriptable type here
+      // runs artifact content as the app. Each of these must be downgraded.
+      const scriptableTypes = [
+        'text/html',
+        'text/html; charset=utf-8',
+        'TEXT/HTML',
+        'application/xhtml+xml',
+        'image/svg+xml',
+        'text/xml',
+        'application/xml',
+      ];
+      const openBlobUrlSpy = spyOn(service, 'openBlobUrl').and.returnValue({
+        focus: () => {},
+      } as Window);
+
+      for (const mimeType of scriptableTypes) {
+        openBlobUrlSpy.calls.reset();
+
+        service.openBase64InNewTab(btoa('<script>alert(1)</script>'), mimeType);
+
+        const blob = openBlobUrlSpy.calls.mostRecent().args[0];
+        expect(blob.type)
+            .withContext(mimeType)
+            .toEqual('application/octet-stream');
+      }
+    });
+
+    it('should preserve the type of inert content', () => {
+      const openBlobUrlSpy = spyOn(service, 'openBlobUrl').and.returnValue({
+        focus: () => {},
+      } as Window);
+
+      service.openBase64InNewTab(btoa('plain'), 'text/plain');
+
+      expect(openBlobUrlSpy.calls.mostRecent().args[0].type)
+          .toEqual('text/plain');
+    });
+
     it('should do nothing if dataUrl is empty', () => {
       const openBlobUrlSpy = spyOn(service, 'openBlobUrl');
       service.openBase64InNewTab('', 'image/png');


### PR DESCRIPTION
openBase64InNewTab built the blob with the artifact's own MIME type and handed it to window.open. A blob URL inherits the origin of the page that created it, so a text/html or image/svg+xml artifact opened in a tab ran with the Dev UI's origin and a live window.opener handle back into the session. Artifact bytes are untrusted: an agent, a tool, or an upload produces them.

Downgrade the blob type to application/octet-stream for MIME types the browser parses into a scriptable document, so those artifacts download rather than render. Inert types are unchanged.