### PR TITLE
feat(a2ui): add A2UI spec v0.9 rendering support alongside v0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "agent-framework-web",
       "version": "0.0.0",
       "dependencies": {
-        "@a2ui/angular": "^0.8.3",
+        "@a2ui/angular": "^0.9.1",
+        "@a2ui/lit": "^0.8.3",
+        "@a2ui/markdown-it": "^0.0.3",
         "@angular/animations": "^21.0.0",
         "@angular/cdk": "^21.0.0",
         "@angular/common": "^21.0.0",
@@ -51,18 +53,35 @@
       }
     },
     "node_modules/@a2ui/angular": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@a2ui/angular/-/angular-0.8.3.tgz",
-      "integrity": "sha512-157/CVJy65ZJb9okg+W9MQ8A36YmrHdh8pe5Ina4f+LulXOeiXNDtQxuG9PrngcC0Sa2dWNzHGS6Ns0hIotf/Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@a2ui/angular/-/angular-0.9.1.tgz",
+      "integrity": "sha512-P35j7l/1Id3VkpmNm5LNCnsuSzM/eA3RRg4knCAD0mwaAgHNxsYT0FGYiTyeFIFoWck0foxNnh6I0hiKb7QJjw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@a2ui/lit": "^0.8.1",
-        "markdown-it": "^14.1.0",
-        "tslib": "^2.3.0"
+        "@a2ui/web_core": "^0.9.2",
+        "@preact/signals-core": "^1.13.0",
+        "tslib": "^2.3.0",
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0"
+        "@a2ui/markdown-it": "^0.0.3",
+        "@angular/common": "^21.2.0",
+        "@angular/core": "^21.2.0",
+        "@angular/platform-browser": "^21.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@a2ui/markdown-it": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@a2ui/angular/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@a2ui/lit": {
@@ -78,12 +97,46 @@
         "signal-utils": "^0.21.1"
       }
     },
-    "node_modules/@a2ui/web_core": {
+    "node_modules/@a2ui/lit/node_modules/@a2ui/web_core": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@a2ui/web_core/-/web_core-0.8.0.tgz",
       "integrity": "sha512-UG8IDsiLYuZjnEmqH7129EbN1Ds3DfC8FXPSI/E+0kcZ4VGxo//Kij6ZF2jBXBKyrHYPehoDtffFFIIFvgBp6g==",
       "license": "Apache-2.0",
       "dependencies": {
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.1"
+      }
+    },
+    "node_modules/@a2ui/lit/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@a2ui/markdown-it": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@a2ui/markdown-it/-/markdown-it-0.0.3.tgz",
+      "integrity": "sha512-ni/aK2oeBcjEESTO+XE+CidDb0N4aOzYL14XSYBAdAH2E7jmsbuUyHEKf4FQyYK0f8AA0C5thkZ09qPV2C3ikA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "markdown-it": "^14.1.0"
+      },
+      "peerDependencies": {
+        "@a2ui/web_core": "^0.9.2"
+      }
+    },
+    "node_modules/@a2ui/web_core": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@a2ui/web_core/-/web_core-0.9.2.tgz",
+      "integrity": "sha512-EOfhLOF7tnpPmNq4y116k3gxWdrXQW8h3dhKF0pC++21zLZnCSLSHl6zgQFG+kPeVAZb64t+sQiRXlnyS8+RBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@preact/signals-core": "^1.13.0",
+        "date-fns": "^4.1.0",
         "zod": "^3.25.76",
         "zod-to-json-schema": "^3.25.1"
       }
@@ -5630,6 +5683,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@replit/codemirror-indentation-markers": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/@replit/codemirror-indentation-markers/-/codemirror-indentation-markers-6.5.3.tgz",
@@ -9192,6 +9255,16 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
@@ -12154,9 +12227,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -12533,14 +12616,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -12573,9 +12666,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "license": "MIT"
     },
     "node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "private": true,
   "dependencies": {
-    "@a2ui/angular": "^0.8.3",
+    "@a2ui/angular": "^0.9.1",
+    "@a2ui/lit": "^0.8.3",
+    "@a2ui/markdown-it": "^0.0.3",
     "@angular/animations": "^21.0.0",
     "@angular/cdk": "^21.0.0",
     "@angular/common": "^21.0.0",

--- a/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.scss
+++ b/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.scss
@@ -1,0 +1,26 @@
+/*
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}
+
+:host ::ng-deep * {
+  box-sizing: border-box;
+}

--- a/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.scss
+++ b/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.scss
@@ -14,13 +14,191 @@
  limitations under the License.
  */
 
+// A2UI v0.9 theming, mapped onto adk-web's Material system tokens.
+//
+// Unlike v0.8 -- which is themed in TypeScript through the `Theme` token
+// (see core/constants/a2ui-theme.ts) -- v0.9 has no theme object at all. It
+// injects no root stylesheet and no `a2ui-light`/`a2ui-dark` classes; every
+// component styles itself with inline `var(--a2ui-X, <fallback>)`, and all but
+// a handful of those fallbacks are hardcoded light-mode values (#fff, #333,
+// #ccc). Without this block, v0.9 surfaces are unreadable in adk-web's default
+// dark theme, so it is not cosmetic.
+//
+// Everything here is pure indirection: `var()` resolves at use time, so a
+// theme flip repaints `--mat-sys-*`, which repaints `--a2ui-*`, with no
+// JavaScript and no second definition site. ThemeService and styles.scss stay
+// untouched.
+//
+// Scoped to `:host` rather than a global stylesheet so `--a2ui-*` does not
+// leak into the global namespace of an app that embeds this component. Safe
+// for v0.9's Modal, which is a plain `position: fixed` element inside its own
+// template -- no CDK overlay, no body portal -- so it stays in this subtree
+// and inherits.
 :host {
   display: block;
   height: 100%;
   width: 100%;
   overflow: auto;
+
+  // --- Color -----------------------------------------------------------
+  // A surface is drawn inside a chat bubble that is already
+  // `--mat-sys-surface-container`, so cards step one level away from it
+  // rather than sitting flat on top.
+  --a2ui-color-surface: var(--mat-sys-surface-container-low);
+  --a2ui-color-on-background: var(--mat-sys-on-surface);
+  --a2ui-color-border: var(--mat-sys-outline-variant);
+  --a2ui-color-primary: var(--mat-sys-primary);
+  --a2ui-color-on-primary: var(--mat-sys-on-primary);
+  // Only used as the *border* colour of the primary button. Matching it to the
+  // fill keeps that button borderless, as it is under the v0.8 theme.
+  --a2ui-color-primary-hover: var(--mat-sys-primary);
+  // Slider track only.
+  --a2ui-color-secondary: var(--mat-sys-secondary-container);
+  // Not a typo, and not `--mat-sys-on-secondary-container`: upstream uses this
+  // as the foreground of the *default* button, whose background is
+  // `--a2ui-color-surface`. The intuitive mapping gives low-contrast text.
+  --a2ui-color-on-secondary: var(--mat-sys-on-surface);
+  --a2ui-color-input: var(--mat-sys-surface-container-high);
+  --a2ui-color-on-input: var(--mat-sys-on-surface);
+  --a2ui-color-error: var(--mat-sys-error);
+
+  // --- Text ------------------------------------------------------------
+  --a2ui-text-color-text: var(--mat-sys-on-surface);
+  --a2ui-text-color: var(--mat-sys-on-surface);
+  --a2ui-text-caption-color: var(--mat-sys-on-surface-variant);
+  --a2ui-text-a-color: var(--mat-sys-primary);
+  --a2ui-text-a-font-weight: 500;
+  --a2ui-text-margin: 0 0 8px;
+  --a2ui-icon-color: var(--mat-sys-on-surface-variant);
+
+  // --- Typography ------------------------------------------------------
+  // The six font sizes are mandatory, not optional: upstream reads them as
+  // bare `var(--a2ui-font-size-l)` with no fallback, and an undefined custom
+  // property invalidates the whole declaration -- every heading would fall
+  // back to the browser default. Mapped onto the Material scale so the ramp
+  // stays monotone; each carries a literal fallback as a second line of
+  // defence.
+  --a2ui-font-family-title: var(--mat-sys-title-large-font, 'Google Sans', Roboto, sans-serif);
+  --a2ui-font-size-2xl: var(--mat-sys-headline-small-size, 24px);
+  --a2ui-font-size-xl: var(--mat-sys-title-large-size, 22px);
+  --a2ui-font-size-l: var(--mat-sys-title-medium-size, 16px);
+  --a2ui-font-size-m: var(--mat-sys-body-medium-size, 14px);
+  --a2ui-font-size-s: var(--mat-sys-body-small-size, 12px);
+  --a2ui-font-size-xs: var(--mat-sys-label-small-size, 11px);
+  --a2ui-label-font-size: var(--mat-sys-body-medium-size, 14px);
+  --a2ui-line-height-body: var(--mat-sys-body-medium-line-height, 1.5);
+  // Unitless on purpose: this applies to h1 through h6, which are six
+  // different sizes, so an absolute Material line-height token would be wrong
+  // for five of them.
+  --a2ui-line-height-headings: 1.2;
+
+  // --- Spacing (8px system) --------------------------------------------
+  --a2ui-spacing-xs: 4px;
+  --a2ui-spacing-s: 8px;
+  --a2ui-spacing-m: 16px;
+  --a2ui-spacing-l: 24px;
+  --a2ui-spacing-xl: 32px;
+  --a2ui-row-gap: 16px;
+  --a2ui-column-gap: 16px;
+  --a2ui-list-gap: 8px;
+  --a2ui-list-padding: 24px;
+  --a2ui-divider-spacing: 16px;
+
+  // --- Shape -----------------------------------------------------------
+  --a2ui-border-radius: var(--mat-sys-corner-medium, 12px);
+  --a2ui-border-width: 1px;
+
+  // --- Card ------------------------------------------------------------
+  // No shadow and no margin: the surface already sits inside an elevated chat
+  // bubble, so upstream's drop shadow reads as a double border and its 16px
+  // margin double-pads the bubble.
+  --a2ui-card-background: var(--mat-sys-surface-container);
+  --a2ui-card-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-card-border-radius: var(--mat-sys-corner-medium, 12px);
+  --a2ui-card-box-shadow: none;
+  --a2ui-card-margin: 0;
+  --a2ui-card-padding: 16px;
+
+  // --- Button ----------------------------------------------------------
+  // Mirrors the v0.8 theme's button: pill radius, no shadow, medium weight.
+  --a2ui-button-background: var(--mat-sys-surface-container-high);
+  --a2ui-button-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-button-border-radius: var(--mat-sys-corner-large, 16px);
+  --a2ui-button-box-shadow: none;
+  --a2ui-button-font-weight: 500;
+  --a2ui-button-margin: 0 8px 8px 0;
+  --a2ui-button-padding: 8px 20px;
+
+  // --- TextField / DateTimeInput ---------------------------------------
+  --a2ui-textfield-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-textfield-border-radius: var(--mat-sys-corner-small, 8px);
+  --a2ui-textfield-padding: 8px 12px;
+  --a2ui-textfield-color-border-focus: var(--mat-sys-primary);
+  --a2ui-textfield-color-error: var(--mat-sys-error);
+  --a2ui-textfield-label-font-weight: 500;
+  --a2ui-datetimeinput-background: var(--mat-sys-surface-container-high);
+  --a2ui-datetimeinput-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-datetimeinput-border-radius: var(--mat-sys-corner-small, 8px);
+  --a2ui-datetimeinput-color: var(--mat-sys-on-surface);
+  --a2ui-datetimeinput-padding: 8px 12px;
+  --a2ui-datetimeinput-label-font-weight: 500;
+
+  // --- CheckBox / ChoicePicker -----------------------------------------
+  --a2ui-checkbox-border-radius: var(--mat-sys-corner-extra-small, 4px);
+  --a2ui-checkbox-color-error: var(--mat-sys-error);
+  --a2ui-checkbox-gap: 8px;
+  --a2ui-checkbox-label-font-weight: 500;
+  --a2ui-checkbox-margin: 0 0 8px;
+  --a2ui-choicepicker-chip-background: var(--mat-sys-surface-container-high);
+  --a2ui-choicepicker-chip-background-selected: var(--mat-sys-primary);
+  --a2ui-choicepicker-chip-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-choicepicker-gap: 8px;
+
+  // --- Tabs ------------------------------------------------------------
+  --a2ui-tabs-border: 1px solid var(--mat-sys-outline-variant);
+  --a2ui-tabs-header-color: var(--mat-sys-on-surface-variant);
+  --a2ui-tabs-header-color-active: var(--mat-sys-primary);
+
+  // --- Slider ----------------------------------------------------------
+  --a2ui-slider-label-font-weight: 500;
+  --a2ui-slider-margin: 0 0 16px;
+  --a2ui-slider-thumb-color: var(--mat-sys-primary);
+  --a2ui-slider-track-color: var(--mat-sys-secondary-container);
+
+  // --- Modal -----------------------------------------------------------
+  --a2ui-modal-background: var(--mat-sys-surface-container-high);
+  --a2ui-modal-border-radius: var(--mat-sys-corner-large, 16px);
+  --a2ui-modal-box-shadow: var(--mat-sys-level3);
+  --a2ui-modal-padding: 24px;
+  // Left theme-independent: a scrim darkens whatever is behind it in both
+  // light and dark mode, and `--mat-sys-scrim` is an opaque hex that would
+  // need color-mix() to become one.
+  --a2ui-modal-backdrop-bg: rgba(0, 0, 0, 0.5);
+
+  // --- Image -----------------------------------------------------------
+  // Only the large feature size is overridden; 400px overflows a chat bubble.
+  --a2ui-image-border-radius: var(--mat-sys-corner-medium, 12px);
+  --a2ui-image-large-feature-size: 320px;
+  --a2ui-video-border-radius: var(--mat-sys-corner-medium, 12px);
 }
 
 :host ::ng-deep * {
   box-sizing: border-box;
+}
+
+// Upstream hardcodes the disabled button's colours with no custom property to
+// hook, so they can only be reached from outside. Remove once v0.9 tokenizes
+// them.
+:host ::ng-deep .a2ui-button:disabled {
+  background-color: var(--mat-sys-surface-container-highest);
+  color: var(--mat-sys-on-surface-variant);
+  border-color: var(--mat-sys-outline-variant);
+}
+
+// The v0.9 CheckBox is a bare `<input type="checkbox">` without
+// `appearance: none`, so its `--a2ui-checkbox-background`/`-border` variables
+// are inert and the control renders in the browser's own light-mode chrome.
+// `accent-color` is the one property a native checkbox honours.
+:host ::ng-deep .a2ui-check-box-input {
+  accent-color: var(--mat-sys-primary);
 }

--- a/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.spec.ts
+++ b/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import {A2uiRendererService} from '@a2ui/angular/v0_9';
+import {SimpleChanges} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+
+import {initTestBed} from '../../testing/utils';
+
+import {A2uiCanvasV09Component} from './a2ui-canvas-v09.component';
+
+/** A v0.9 message batch that builds one surface. */
+const CREATE_SURFACE = {
+  version: 'v0.9',
+  createSurface: {
+    surfaceId: 'dash',
+    catalogId: 'https://a2ui.org/specification/v0_9/basic_catalog.json'
+  }
+};
+const UPDATE_COMPONENTS = {
+  version: 'v0.9',
+  updateComponents: {surfaceId: 'dash', components: []}
+};
+
+describe('A2uiCanvasV09Component', () => {
+  let component: A2uiCanvasV09Component;
+  let fixture: ComponentFixture<A2uiCanvasV09Component>;
+  let mockRenderer: jasmine.SpyObj<A2uiRendererService>;
+  let surfaces: Map<string, unknown>;
+
+  /** Builds the SimpleChanges record Angular would pass for `messages`. */
+  const changeRecord = (currentValue: unknown): SimpleChanges => ({
+    messages: {
+      currentValue,
+      previousValue: null,
+      firstChange: true,
+      isFirstChange: () => true
+    }
+  });
+
+  beforeEach(async () => {
+    initTestBed();
+    surfaces = new Map<string, unknown>();
+    // `surfaceGroup` is a getter, so it has to be spied as a property rather
+    // than listed among the methods.
+    mockRenderer = jasmine.createSpyObj<A2uiRendererService>(
+        'A2uiRendererService', ['processMessages'], {
+          surfaceGroup: {
+            getSurface: (id: string) => surfaces.get(id),
+          } as any,
+        });
+
+    await TestBed
+        .configureTestingModule({
+          imports: [A2uiCanvasV09Component],
+          providers: [
+            {provide: A2uiRendererService, useValue: mockRenderer},
+          ],
+        })
+        .compileComponents();
+
+    fixture = TestBed.createComponent(A2uiCanvasV09Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should process each message and derive the surfaceId', () => {
+    const consoleError = spyOn(console, 'error');
+    const messages = [CREATE_SURFACE, UPDATE_COMPONENTS];
+    component.messages = messages;
+
+    component.ngOnChanges(changeRecord(messages));
+
+    // One call per message, not one batched call: a throw mid-batch would
+    // abandon every message after it.
+    expect(mockRenderer.processMessages).toHaveBeenCalledTimes(2);
+    expect(mockRenderer.processMessages)
+        .toHaveBeenCalledWith([CREATE_SURFACE] as any);
+    expect(mockRenderer.processMessages)
+        .toHaveBeenCalledWith([UPDATE_COMPONENTS] as any);
+    expect(component.surfaceId()).toBe('dash');
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('should derive the surfaceId from updateComponents alone', () => {
+    // The streaming case: createSurface arrived in an earlier event, so this
+    // bubble sees only updates.
+    const messages = [UPDATE_COMPONENTS];
+    component.messages = messages;
+
+    component.ngOnChanges(changeRecord(messages));
+
+    expect(component.surfaceId()).toBe('dash');
+  });
+
+  it('should do nothing without a messages change record', () => {
+    component.messages = [CREATE_SURFACE];
+
+    component.ngOnChanges({});
+
+    expect(mockRenderer.processMessages).not.toHaveBeenCalled();
+    expect(component.surfaceId()).toBeNull();
+  });
+
+  it('should not reprocess the same array instance twice', () => {
+    const messages = [CREATE_SURFACE];
+    component.messages = messages;
+
+    component.ngOnChanges(changeRecord(messages));
+    component.ngOnChanges(changeRecord(messages));
+
+    expect(mockRenderer.processMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('should do nothing for an empty or null batch', () => {
+    component.messages = [];
+    component.ngOnChanges(changeRecord([]));
+    component.messages = null;
+    component.ngOnChanges(changeRecord(null));
+
+    expect(mockRenderer.processMessages).not.toHaveBeenCalled();
+    expect(component.surfaceId()).toBeNull();
+  });
+
+  it('should skip a createSurface for a surface that already exists', () => {
+    // v0.9's processor throws "Surface dash already exists" here. Skipping the
+    // create lets the idempotent updates land on the existing surface, which is
+    // what makes a history reload work.
+    surfaces.set('dash', {});
+    const messages = [CREATE_SURFACE, UPDATE_COMPONENTS];
+    component.messages = messages;
+
+    component.ngOnChanges(changeRecord(messages));
+
+    expect(mockRenderer.processMessages).toHaveBeenCalledTimes(1);
+    expect(mockRenderer.processMessages)
+        .toHaveBeenCalledWith([UPDATE_COMPONENTS] as any);
+    expect(component.surfaceId()).toBe('dash');
+  });
+
+  it('should contain a failed message and still process the rest', () => {
+    const consoleError = spyOn(console, 'error');
+    mockRenderer.processMessages.and.callFake((batch: any) => {
+      if (batch[0] === CREATE_SURFACE) throw new Error('catalog not found');
+    });
+    const messages = [CREATE_SURFACE, UPDATE_COMPONENTS];
+    component.messages = messages;
+
+    expect(() => component.ngOnChanges(changeRecord(messages))).not.toThrow();
+
+    expect(mockRenderer.processMessages).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('should not mount the surface before its messages are processed', () => {
+    // `ComponentHostComponent` looks its surface up once in ngOnInit and, on a
+    // miss, warns and never retries -- so the @if gate on surfaceId is
+    // load-bearing, not cosmetic.
+    expect(fixture.nativeElement.querySelector('a2ui-v09-surface')).toBeNull();
+
+    const messages = [CREATE_SURFACE];
+    component.messages = messages;
+    component.ngOnChanges(changeRecord(messages));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('a2ui-v09-surface'))
+        .not.toBeNull();
+  });
+});

--- a/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.ts
+++ b/src/app/components/a2ui-canvas/a2ui-canvas-v09.component.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {A2uiRendererService, SurfaceComponent} from '@a2ui/angular/v0_9';
+import {ChangeDetectionStrategy, Component, inject, Input, OnChanges, signal, SimpleChanges,} from '@angular/core';
+
+/** The message type the v0.9 renderer accepts. */
+type A2uiV09Message =
+    Parameters<A2uiRendererService['processMessages']>[0][number];
+
+/**
+ * Renders an A2UI spec v0.9 surface.
+ *
+ * A sibling of `A2uiCanvasComponent` rather than a branch inside it: the two
+ * renderers have different lifecycles. v0.8's `<a2ui-surface>` needs a resolved
+ * surface object re-read from a map on every change, while v0.9's
+ * `<a2ui-v09-surface>` takes only a surfaceId and resolves internally.
+ */
+@Component({
+  selector: 'app-a2ui-canvas-v09',
+  template: `
+    @if (surfaceId()) {
+      <a2ui-v09-surface [surfaceId]="surfaceId()!" />
+    }
+  `,
+  styleUrls: ['./a2ui-canvas-v09.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SurfaceComponent],
+})
+export class A2uiCanvasV09Component implements OnChanges {
+  private readonly renderer = inject(A2uiRendererService);
+
+  /** The de-enveloped v0.9 messages for this bubble, in send order. */
+  @Input() messages: readonly unknown[]|null = null;
+
+  readonly surfaceId = signal<string|null>(null);
+
+  /**
+   * The last array instance processed. The renderer service is root-scoped, so
+   * re-processing the same batch would duplicate work and log spurious
+   * "surface already exists" failures on every change-detection pass.
+   */
+  private lastProcessed: readonly unknown[]|null = null;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes['messages']) return;
+
+    const messages = this.messages;
+    if (!messages || messages.length === 0) return;
+    if (messages === this.lastProcessed) return;
+    this.lastProcessed = messages;
+
+    for (const message of messages) {
+      this.processMessage(message);
+    }
+
+    // Derive the surfaceId only after processing, so the template's @if gate
+    // cannot mount the child before its surface exists. `ComponentHostComponent`
+    // looks the surface up once in ngOnInit and, on a miss, warns and never
+    // retries -- unlike a missing component, which recovers via onCreated.
+    const surfaceId = this.surfaceIdOf(messages);
+    if (surfaceId) {
+      this.surfaceId.set(surfaceId);
+    }
+  }
+
+  /**
+   * Processes one message in isolation.
+   *
+   * Per-message rather than one batched `processMessages` call because v0.9's
+   * processor throws on a duplicate `createSurface`, an unknown catalogId, and
+   * an update naming an absent surface -- and a throw mid-batch would abandon
+   * every remaining message, leaving a half-built surface.
+   */
+  private processMessage(message: unknown): void {
+    if (this.isRedundantCreateSurface(message)) return;
+
+    try {
+      this.renderer.processMessages([message as A2uiV09Message]);
+    } catch (e: unknown) {
+      console.error('Failed to process an A2UI v0.9 message:', e, message);
+    }
+  }
+
+  /**
+   * True when this `createSurface` names a surface that already exists.
+   *
+   * The renderer service is root-scoped and its surfaces outlive any one
+   * bubble, so re-creating one -- on a history reload, or when a bubble
+   * re-processes its batch -- would throw "Surface <id> already exists". Since
+   * the subsequent update messages are idempotent upserts against the existing
+   * surface, skipping the create is the correct recovery: the already-mounted
+   * child keeps a valid surface reference and simply receives the new
+   * components.
+   */
+  private isRedundantCreateSurface(message: unknown): boolean {
+    if (!message || typeof message !== 'object') return false;
+    const create = (message as Record<string, unknown>)['createSurface'];
+    if (!create || typeof create !== 'object') return false;
+
+    const surfaceId = (create as Record<string, unknown>)['surfaceId'];
+    if (typeof surfaceId !== 'string') return false;
+
+    return this.renderer.surfaceGroup?.getSurface(surfaceId) !== undefined;
+  }
+
+  /** The first surfaceId named by any message in the batch. */
+  private surfaceIdOf(messages: readonly unknown[]): string|null {
+    for (const message of messages) {
+      if (!message || typeof message !== 'object') continue;
+      for (const body of Object.values(message as Record<string, unknown>)) {
+        if (body && typeof body === 'object') {
+          const surfaceId = (body as Record<string, unknown>)['surfaceId'];
+          if (typeof surfaceId === 'string') return surfaceId;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/app/components/a2ui-canvas/a2ui-canvas.component.spec.ts
+++ b/src/app/components/a2ui-canvas/a2ui-canvas.component.spec.ts
@@ -16,8 +16,7 @@
  */
 
 
-import {MessageProcessor} from '@a2ui/angular';
-import {Types} from '@a2ui/lit/0.8';
+import {MessageProcessor, Types} from '@a2ui/angular/v0_8';
 import {SimpleChanges} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 // 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
@@ -177,6 +176,49 @@ describe('A2uiCanvasComponent', () => {
 
     expect(mockMessageProcessor.processMessages).toHaveBeenCalledWith([message]);
     expect(component.surfaceId()).toBe('sales_data_yearly_surface');
+  });
+
+  it('should not log when a message processes cleanly', () => {
+    const consoleError = spyOn(console, 'error');
+    const message = {
+      beginRendering: {surfaceId: 'sales_data_yearly_surface', root: 'root'}
+    } as unknown as Types.ServerToClientMessage;
+    component.beginRendering = message;
+
+    component.ngOnChanges({
+      beginRendering: {
+        currentValue: message,
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('should contain a processor failure instead of propagating it', () => {
+    // The processor schema-validates and throws on a malformed message. A bad
+    // payload must break only its own widget, not change detection for the
+    // whole chat view -- and it must still be visible in the console.
+    const consoleError = spyOn(console, 'error');
+    mockMessageProcessor.processMessages.and.throwError('malformed message');
+    const message = {beginRendering: {surfaceId: 'surface-1', root: 'root'}} as
+        unknown as Types.ServerToClientMessage;
+    component.beginRendering = message;
+
+    expect(() => component.ngOnChanges({
+      beginRendering: {
+        currentValue: message,
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true
+      }
+    })).not.toThrow();
+
+    expect(consoleError).toHaveBeenCalled();
+    // The surfaceId is still derived, so a later valid message can recover.
+    expect(component.surfaceId()).toBe('surface-1');
   });
 
   it('should update activeSurface when surfaceId matches', () => {

--- a/src/app/components/a2ui-canvas/a2ui-canvas.component.ts
+++ b/src/app/components/a2ui-canvas/a2ui-canvas.component.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import {MessageProcessor, Surface} from '@a2ui/angular';
-import {Types} from '@a2ui/lit/0.8';
+import {MessageProcessor, Surface, Types} from '@a2ui/angular/v0_8';
 import {CommonModule} from '@angular/common';
 import {ChangeDetectionStrategy, Component, computed, inject, Input, OnChanges, signal, SimpleChanges,} from '@angular/core';
 
@@ -66,7 +65,14 @@ export class A2uiCanvasComponent implements OnChanges {
     }
 
     if (messages.length > 0) {
-      this.processor.processMessages(messages);
+      try {
+        this.processor.processMessages(messages);
+      } catch (e: unknown) {
+        // The processor schema-validates and throws on a malformed message.
+        // Contain it: an agent sending bad markup should break its own widget,
+        // not change detection for the whole chat view.
+        console.error('Failed to process A2UI v0.8 messages:', e);
+      }
     }
 
     if (detectedSurfaceId) {

--- a/src/app/components/chat-panel/chat-panel.component.spec.ts
+++ b/src/app/components/chat-panel/chat-panel.component.spec.ts
@@ -183,6 +183,10 @@ describe('ChatPanelComponent', () => {
       expect(component.removeFile.emit).toHaveBeenCalledWith(0);
     });
 
+    // Left disabled: chat-panel does not own the canvas (the chain is
+    // chat-panel -> event-row -> event-content -> content-bubble ->
+    // a2ui-canvas) and this TestBed provides none of the A2UI DI graph.
+    // `content-bubble.component.spec.ts` covers the dispatch directly.
     xit('should display A2UI canvas', () => {
       component.uiEvents = [
         new UiEvent({

--- a/src/app/components/chat-panel/chat-panel.component.ts
+++ b/src/app/components/chat-panel/chat-panel.component.ts
@@ -53,7 +53,6 @@ import { UI_STATE_SERVICE } from '../../core/services/interfaces/ui-state';
 import { THEME_SERVICE } from '../../core/services/interfaces/theme';
 import { JsonTooltipDirective } from '../../directives/html-tooltip.directive';
 import { WorkflowGraphTooltipDirective } from '../../directives/workflow-graph-tooltip.directive';
-import { A2uiCanvasComponent } from '../a2ui-canvas/a2ui-canvas.component';
 import { MediaType, } from '../artifact-tab/artifact-tab.component';
 import { AudioPlayerComponent } from '../audio-player/audio-player.component';
 import { ComputerActionComponent } from '../computer-action/computer-action.component';

--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import {Catalog, DEFAULT_CATALOG, provideMarkdownRenderer, Theme} from '@a2ui/angular/v0_8';
 import {Location} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
 import {ChangeDetectionStrategy, Component, ElementRef, ErrorHandler} from '@angular/core';
@@ -27,6 +28,7 @@ import {ActivatedRoute, NavigationEnd, Router, UrlTree} from '@angular/router';
 // 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
 import {BehaviorSubject, NEVER, of, ReplaySubject, Subject, throwError} from 'rxjs';
 
+import {A2UI_THEME} from '../../core/constants/a2ui-theme';
 import {EvalCase} from '../../core/models/Eval';
 import {Session} from '../../core/models/Session';
 import {UiEvent} from '../../core/models/UiEvent';
@@ -266,6 +268,12 @@ describe('ChatComponent', () => {
             TestHostComponent,
           ],
           providers: [
+            // Mirrors main.ts. A schema-valid A2UI payload renders a real
+            // surface, and the renderer resolves these during construction --
+            // outside any try/catch the canvas can install.
+            {provide: Catalog, useValue: DEFAULT_CATALOG},
+            {provide: Theme, useValue: A2UI_THEME},
+            provideMarkdownRenderer(),
             {provide: EVAL_TAB_COMPONENT, useValue: EvalTabComponent},
             {provide: SESSION_SERVICE, useValue: mockSessionService},
             {provide: ARTIFACT_SERVICE, useValue: mockArtifactService},
@@ -527,6 +535,20 @@ describe('ChatComponent', () => {
             };
           };
 
+          // These must validate against the v0.8 message schema: the renderer
+          // schema-checks every message and throws on a malformed one.
+          const beginRendering = {
+            beginRendering: {surfaceId: 'surface-1', root: 'root'}
+          };
+          const surfaceUpdate = {
+            surfaceUpdate: {
+              surfaceId: 'surface-1',
+              components: [
+                {id: 'root', component: {Text: {text: {literalString: 'hello'}}}}
+              ]
+            }
+          };
+
           const historyEvent = {
             id: 'event-history',
             author: 'bot',
@@ -534,8 +556,8 @@ describe('ChatComponent', () => {
             content: {
               role: 'bot',
               parts: [
-                createA2uiPart({beginRendering: {id: '1'}}),
-                createA2uiPart({surfaceUpdate: {components: []}})
+                createA2uiPart(beginRendering),
+                createA2uiPart(surfaceUpdate)
               ]
             },
           };
@@ -550,8 +572,8 @@ describe('ChatComponent', () => {
           const messages = component.uiEvents();
           expect(component.uiEvents().length).toBe(1);
           expect(component.uiEvents()[0].a2uiData).toEqual({
-            beginRendering: {beginRendering: {id: '1'}},
-            surfaceUpdate: {surfaceUpdate: {components: []}}
+            beginRendering,
+            surfaceUpdate,
           });
         });
       });

--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -16,9 +16,10 @@
  */
 
 import {Catalog, DEFAULT_CATALOG, provideMarkdownRenderer, Theme} from '@a2ui/angular/v0_8';
+import {A2UI_RENDERER_CONFIG, A2uiRendererService, BasicCatalog, provideMarkdownRenderer as provideV09MarkdownRenderer} from '@a2ui/angular/v0_9';
 import {Location} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
-import {ChangeDetectionStrategy, Component, ElementRef, ErrorHandler} from '@angular/core';
+import {ChangeDetectionStrategy, Component, ElementRef, ErrorHandler, inject} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDialog, MatDialogModule} from '@angular/material/dialog';
 import { SnackbarService } from '../../core/services/snackbar.service';
@@ -274,6 +275,14 @@ describe('ChatComponent', () => {
             {provide: Catalog, useValue: DEFAULT_CATALOG},
             {provide: Theme, useValue: A2UI_THEME},
             provideMarkdownRenderer(),
+            // The real v0.9 renderer, not a stub, so the A2UI tests below
+            // exercise the same graph production uses.
+            {
+              provide: A2UI_RENDERER_CONFIG,
+              useFactory: () => ({catalogs: [inject(BasicCatalog)]})
+            },
+            A2uiRendererService,
+            provideV09MarkdownRenderer(),
             {provide: EVAL_TAB_COMPONENT, useValue: EvalTabComponent},
             {provide: SESSION_SERVICE, useValue: mockSessionService},
             {provide: ARTIFACT_SERVICE, useValue: mockArtifactService},
@@ -582,6 +591,10 @@ describe('ChatComponent', () => {
         });
 
         it('should combine v0.9 A2UI data parts in history messages', () => {
+          // The real v0.9 renderer is wired up here, so this also proves the
+          // canonical catalogId below is accepted -- a mismatch is the top
+          // integration gotcha and its only symptom is a silent empty surface.
+          const consoleError = spyOn(console, 'error');
           const createSurface = {
             version: 'v0.9',
             createSurface: {
@@ -627,6 +640,8 @@ describe('ChatComponent', () => {
           ]);
           expect(a2uiData.surfaceId).toBe('surface-9');
           expect(a2uiData.beginRendering).toBeUndefined();
+          // Nothing degraded silently on the way through the real renderer.
+          expect(consoleError).not.toHaveBeenCalled();
         });
       });
     });

--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -519,22 +519,23 @@ describe('ChatComponent', () => {
           expect(component.eventData.has('event-2')).toBeTrue();
         });
 
-        it('should combine A2UI data parts in history messages', () => {
-          const createA2uiPart = (content: any) => {
-            const json = JSON.stringify({
-              kind: 'data',
-              metadata: {mimeType: A2UI_MIME_TYPE},
-              data: content
-            });
-            return {
-              inlineData: {
-                mimeType: 'text/plain',
-                data: btoa(`${A2A_DATA_PART_TAG_START}${json}${
-                    A2A_DATA_PART_TAG_END}`)
-              }
-            };
+        /** Wraps an A2UI message as the A2A DataPart the history path sees. */
+        const createA2uiPart = (content: any) => {
+          const json = JSON.stringify({
+            kind: 'data',
+            metadata: {mimeType: A2UI_MIME_TYPE},
+            data: content
+          });
+          return {
+            inlineData: {
+              mimeType: 'text/plain',
+              data: btoa(
+                  `${A2A_DATA_PART_TAG_START}${json}${A2A_DATA_PART_TAG_END}`)
+            }
           };
+        };
 
+        it('should combine A2UI data parts in history messages', () => {
           // These must validate against the v0.8 message schema: the renderer
           // schema-checks every message and throws on a malformed one.
           const beginRendering = {
@@ -572,9 +573,60 @@ describe('ChatComponent', () => {
           const messages = component.uiEvents();
           expect(component.uiEvents().length).toBe(1);
           expect(component.uiEvents()[0].a2uiData).toEqual({
+            version: 'v0.8',
+            messages: [beginRendering, surfaceUpdate],
+            surfaceId: 'surface-1',
             beginRendering,
             surfaceUpdate,
           });
+        });
+
+        it('should combine v0.9 A2UI data parts in history messages', () => {
+          const createSurface = {
+            version: 'v0.9',
+            createSurface: {
+              surfaceId: 'surface-9',
+              catalogId: 'https://a2ui.org/specification/v0_9/basic_catalog.json'
+            }
+          };
+          const updateComponents = {
+            version: 'v0.9',
+            updateComponents: {surfaceId: 'surface-9', components: []}
+          };
+          const updateDataModel = {
+            version: 'v0.9',
+            updateDataModel: {surfaceId: 'surface-9', contents: []}
+          };
+
+          mockUiStateService.newMessagesLoadedResponse.next({
+            items: [{
+              id: 'event-history-v09',
+              author: 'bot',
+              customMetadata: {'a2a:response': 'true'},
+              content: {
+                role: 'bot',
+                parts: [
+                  createA2uiPart(createSurface),
+                  createA2uiPart(updateComponents),
+                  createA2uiPart(updateDataModel),
+                ]
+              },
+            }],
+            nextPageToken: '',
+            isBackground: true
+          } as any);
+          fixture.detectChanges();
+
+          expect(component.uiEvents().length).toBe(1);
+          const a2uiData = component.uiEvents()[0].a2uiData;
+          expect(a2uiData.version).toBe('v0.9');
+          // All three survive: v0.9 sends N updates that the old three-slot,
+          // last-wins shape could not represent.
+          expect(a2uiData.messages).toEqual([
+            createSurface, updateComponents, updateDataModel
+          ]);
+          expect(a2uiData.surfaceId).toBe('surface-9');
+          expect(a2uiData.beginRendering).toBeUndefined();
         });
       });
     });
@@ -1761,6 +1813,32 @@ describe('ChatComponent', () => {
         });
   });
 
+  describe('detectA2uiVersion', () => {
+    const cases: Array<[string, unknown, string|null]> = [
+      ['envelope discriminator v0.9', {version: 'v0.9', createSurface: {}}, 'v0.9'],
+      ['envelope discriminator v0.8', {version: 'v0.8', beginRendering: {}}, 'v0.8'],
+      ['kind key createSurface', {createSurface: {}}, 'v0.9'],
+      ['kind key updateComponents', {updateComponents: {}}, 'v0.9'],
+      ['kind key updateDataModel', {updateDataModel: {}}, 'v0.9'],
+      ['kind key deleteSurface', {deleteSurface: {}}, 'v0.9'],
+      ['kind key beginRendering', {beginRendering: {}}, 'v0.8'],
+      ['kind key surfaceUpdate', {surfaceUpdate: {}}, 'v0.8'],
+      ['kind key dataModelUpdate', {dataModelUpdate: {}}, 'v0.8'],
+      ['discriminator wins over kind key', {version: 'v0.9', beginRendering: {}}, 'v0.9'],
+      ['empty object', {}, null],
+      ['unknown kind', {somethingElse: {}}, null],
+      ['null', null, null],
+      ['a string', 'beginRendering', null],
+      ['an array', [{beginRendering: {}}], null],
+    ];
+
+    for (const [name, input, expected] of cases) {
+      it(`should detect ${name} as ${expected}`, () => {
+        expect((component as any).detectA2uiVersion(input)).toBe(expected);
+      });
+    }
+  });
+
   describe('extractA2uiJsonFromText', () => {
     it('should do nothing if message has no text', () => {
       const uiEvent = new UiEvent({role: 'bot', event: {} as any});
@@ -1790,10 +1868,93 @@ describe('ChatComponent', () => {
       });
 
       (component as any).extractA2uiJsonFromText(uiEvent);
-      expect(uiEvent.a2uiData).toEqual({beginRendering: {beginRendering: {surfaceId: 'cloud_dash'}}});
+      expect(uiEvent.a2uiData).toEqual({
+        version: 'v0.8',
+        messages: payload,
+        surfaceId: 'cloud_dash',
+        beginRendering: {beginRendering: {surfaceId: 'cloud_dash'}},
+      });
       expect(uiEvent.text).toBe('Here is the UI:\n\nEnjoy!');
       expect(uiEvent.textParts).toEqual([{ text: 'Here is the UI:\n\nEnjoy!', thought: false }]);
     });
+
+    it('should extract a v0.9 payload and populate no v0.8 aliases', () => {
+      const payload = [
+        {
+          version: 'v0.9',
+          createSurface: {
+            surfaceId: 'cloud_dash',
+            catalogId: 'https://a2ui.org/specification/v0_9/basic_catalog.json'
+          }
+        },
+        {
+          version: 'v0.9',
+          updateComponents: {surfaceId: 'cloud_dash', components: []}
+        },
+      ];
+      const text = `<a2ui-json>${JSON.stringify(payload)}</a2ui-json>`;
+      const uiEvent = new UiEvent({role: 'bot', text, event: {} as any});
+
+      (component as any).extractA2uiJsonFromText(uiEvent);
+
+      expect(uiEvent.a2uiData.version).toBe('v0.9');
+      expect(uiEvent.a2uiData.messages).toEqual(payload);
+      expect(uiEvent.a2uiData.surfaceId).toBe('cloud_dash');
+      expect(uiEvent.a2uiData.beginRendering).toBeUndefined();
+      expect(uiEvent.a2uiData.surfaceUpdate).toBeUndefined();
+      expect(uiEvent.a2uiData.dataModelUpdate).toBeUndefined();
+      expect(uiEvent.text).toBe('');
+    });
+
+    it('should detect v0.9 from the kind key when version is absent', () => {
+      const text = `<a2ui-json>${
+          JSON.stringify(
+              {updateDataModel: {surfaceId: 's1', contents: []}})}</a2ui-json>`;
+      const uiEvent = new UiEvent({role: 'bot', text, event: {} as any});
+
+      (component as any).extractA2uiJsonFromText(uiEvent);
+
+      expect(uiEvent.a2uiData.version).toBe('v0.9');
+      expect(uiEvent.a2uiData.surfaceId).toBe('s1');
+    });
+
+    it('should leave a2uiData unset for an empty array but still strip the text',
+       () => {
+         const text = `before <a2ui-json>[]</a2ui-json> after`;
+         const uiEvent = new UiEvent({
+           role: 'bot',
+           text,
+           textParts: [{text, thought: false}],
+           event: {} as any
+         });
+
+         (component as any).extractA2uiJsonFromText(uiEvent);
+
+         // Previously this yielded a truthy `{}`, which rendered an empty
+         // canvas. The markup must still never leak into the bubble.
+         expect(uiEvent.a2uiData).toBeUndefined();
+         expect(uiEvent.text).toBe('before  after');
+         expect(uiEvent.textParts).toEqual([
+           {text: 'before  after', thought: false}
+         ]);
+       });
+
+    it('should warn and keep the first version when a batch mixes versions',
+       () => {
+         const consoleWarn = spyOn(console, 'warn');
+         const payload = [
+           {beginRendering: {surfaceId: 's1', root: 'root'}},
+           {createSurface: {surfaceId: 's1', catalogId: 'c'}},
+         ];
+         const text = `<a2ui-json>${JSON.stringify(payload)}</a2ui-json>`;
+         const uiEvent = new UiEvent({role: 'bot', text, event: {} as any});
+
+         (component as any).extractA2uiJsonFromText(uiEvent);
+
+         expect(consoleWarn).toHaveBeenCalled();
+         expect(uiEvent.a2uiData.version).toBe('v0.8');
+         expect(uiEvent.a2uiData.messages).toEqual([payload[0]]);
+       });
 
     it('should keep tags and log warning if JSON parsing fails', () => {
       const uiEvent = new UiEvent({

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -41,6 +41,7 @@ import { combineLatest, firstValueFrom, forkJoin, Observable, of, Subscription }
 import { catchError, distinctUntilChanged, filter, first, map, shareReplay, startWith, switchMap, take, tap } from 'rxjs/operators';
 
 import { URLUtil } from '../../../utils/url-util';
+import { A2UI_V08_KINDS, A2UI_V09_KINDS, A2uiPayload, A2uiSpecVersion } from '../../core/models/A2uiPayload';
 import { AgentRunRequest } from '../../core/models/AgentRunRequest';
 import { EvalCase, EvaluationResult } from '../../core/models/Eval';
 import { Session, SessionState } from '../../core/models/Session';
@@ -1805,18 +1806,112 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     return result;
   }
 
-  private processA2uiPartIntoMessage(part: any): any {
-    const a2uiData: any = {};
-    part.a2ui.forEach((dataPart: any) => {
-      if (dataPart.data.beginRendering) {
-        a2uiData.beginRendering = dataPart.data;
-      } else if (dataPart.data.surfaceUpdate) {
-        a2uiData.surfaceUpdate = dataPart.data;
-      } else if (dataPart.data.dataModelUpdate) {
-        a2uiData.dataModelUpdate = dataPart.data;
+  /**
+   * Identifies which A2UI spec version a message speaks.
+   *
+   * Prefers the explicit `version` discriminator, which the spec places on the
+   * message envelope -- never nested inside the kind object, since v0.9
+   * declares `additionalProperties: false` there. Falls back to matching the
+   * kind key, which is unambiguous because the two versions' kinds are
+   * disjoint.
+   */
+  private detectA2uiVersion(msg: unknown): A2uiSpecVersion|null {
+    if (!msg || typeof msg !== 'object' || Array.isArray(msg)) {
+      return null;
+    }
+    const record = msg as Record<string, unknown>;
+
+    if (record['version'] === 'v0.9') return 'v0.9';
+    if (record['version'] === 'v0.8') return 'v0.8';
+
+    if (A2UI_V09_KINDS.some((kind) => kind in record)) return 'v0.9';
+    if (A2UI_V08_KINDS.some((kind) => kind in record)) return 'v0.8';
+    return null;
+  }
+
+  /** The surfaceId named by a message, whichever kind it is. */
+  private a2uiSurfaceIdOf(msg: unknown): string|undefined {
+    if (!msg || typeof msg !== 'object') return undefined;
+    const record = msg as Record<string, unknown>;
+
+    for (const kind of [...A2UI_V09_KINDS, ...A2UI_V08_KINDS]) {
+      const body = record[kind];
+      if (body && typeof body === 'object') {
+        const surfaceId = (body as Record<string, unknown>)['surfaceId'];
+        if (typeof surfaceId === 'string') return surfaceId;
       }
-    });
-    return a2uiData;
+    }
+    return undefined;
+  }
+
+  /**
+   * Turns a batch of raw A2UI messages into a single version-tagged payload,
+   * dropping empty and unrecognized entries. Returns null when nothing
+   * renderable is left, so callers can leave `a2uiData` unset rather than
+   * binding an empty canvas.
+   */
+  private normalizeA2uiMessages(rawMessages: readonly unknown[]): A2uiPayload
+      |null {
+    const messages: unknown[] = [];
+    let version: A2uiSpecVersion|null = null;
+    let surfaceId: string|undefined;
+
+    for (const raw of rawMessages) {
+      if (!raw || typeof raw !== 'object' ||
+          Object.keys(raw as object).length === 0) {
+        continue;
+      }
+      const detected = this.detectA2uiVersion(raw);
+      if (!detected) continue;
+
+      if (version === null) {
+        version = detected;
+      } else if (detected !== version) {
+        console.warn(`Ignoring an A2UI ${detected} message in a ${
+            version} batch: one event cannot mix spec versions.`);
+        continue;
+      }
+
+      messages.push(raw);
+      surfaceId ??= this.a2uiSurfaceIdOf(raw);
+    }
+
+    if (version === null) return null;
+
+    return {
+      version,
+      messages,
+      ...(surfaceId !== undefined ? {surfaceId} : {}),
+      ...(version === 'v0.8' ? this.a2uiV08Aliases(messages) : {}),
+    };
+  }
+
+  /**
+   * The deprecated per-kind v0.8 aliases, kept so the v0.8 render bindings stay
+   * unchanged. Last message of a given kind wins, matching the prior behavior.
+   */
+  private a2uiV08Aliases(messages: readonly unknown[]): Partial<A2uiPayload> {
+    const aliases: Record<string, unknown> = {};
+    for (const msg of messages) {
+      for (const kind of A2UI_V08_KINDS) {
+        if ((msg as Record<string, unknown>)[kind]) {
+          aliases[kind] = msg;
+          break;
+        }
+      }
+    }
+    return aliases;
+  }
+
+  private processA2uiPartIntoMessage(part: any): A2uiPayload|null {
+    // A2A DataParts arrive enveloped as {kind, metadata, data}; inline JSON
+    // arrives bare. Tolerate both.
+    const rawMessages: unknown[] = (part.a2ui as unknown[] ?? []).map(
+        (dataPart: any) => dataPart && typeof dataPart === 'object' &&
+                'data' in dataPart ?
+            dataPart.data :
+            dataPart);
+    return this.normalizeA2uiMessages(rawMessages);
   }
 
   private extractA2uiJsonFromText(uiEvent: UiEvent) {
@@ -1838,18 +1933,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
         parsed = [parsed];
       }
 
-      const a2uiData: any = {};
-      parsed.forEach((msg: any) => {
-        if (msg.beginRendering) {
-          a2uiData.beginRendering = msg;
-        } else if (msg.surfaceUpdate) {
-          a2uiData.surfaceUpdate = msg;
-        } else if (msg.dataModelUpdate) {
-          a2uiData.dataModelUpdate = msg;
-        }
-      });
-
-      uiEvent.a2uiData = a2uiData;
+      const payload = this.normalizeA2uiMessages(parsed);
+      if (payload) {
+        uiEvent.a2uiData = payload;
+      }
 
       // Strip the <a2ui-json> block from uiEvent.text
       const beforeText = uiEvent.text.substring(0, startIndex);
@@ -1993,7 +2080,10 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
     } else if (part.codeExecutionResult) {
       uiEvent.codeExecutionResult = part.codeExecutionResult;
     } else if (part.a2ui) {
-      uiEvent.a2uiData = this.processA2uiPartIntoMessage(part);
+      const payload = this.processA2uiPartIntoMessage(part);
+      if (payload) {
+        uiEvent.a2uiData = payload;
+      }
     }
   }
 

--- a/src/app/components/content-bubble/content-bubble.component.html
+++ b/src/app/components/content-bubble/content-bubble.component.html
@@ -94,11 +94,16 @@
         </div>
         }
         @if (uiEvent.a2uiData) {
-        <app-a2ui-canvas
-          [beginRendering]="uiEvent.a2uiData.beginRendering"
-          [surfaceUpdate]="uiEvent.a2uiData.surfaceUpdate"
-          [dataModelUpdate]="uiEvent.a2uiData.dataModelUpdate">
-        </app-a2ui-canvas>
+          @if (uiEvent.a2uiData.version === 'v0.9') {
+          <app-a2ui-canvas-v09 [messages]="uiEvent.a2uiData.messages">
+          </app-a2ui-canvas-v09>
+          } @else {
+          <app-a2ui-canvas
+            [beginRendering]="uiEvent.a2uiData.beginRendering"
+            [surfaceUpdate]="uiEvent.a2uiData.surfaceUpdate"
+            [dataModelUpdate]="uiEvent.a2uiData.dataModelUpdate">
+          </app-a2ui-canvas>
+          }
         }
       </div>
     }

--- a/src/app/components/content-bubble/content-bubble.component.spec.ts
+++ b/src/app/components/content-bubble/content-bubble.component.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MessageProcessor} from '@a2ui/angular/v0_8';
+import {A2uiRendererService} from '@a2ui/angular/v0_9';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+// 1p-ONLY-IMPORTS: import {beforeEach, describe, expect, it}
+
+import {UiEvent} from '../../core/models/UiEvent';
+import {ARTIFACT_SERVICE} from '../../core/services/interfaces/artifact';
+import {SAFE_VALUES_SERVICE} from '../../core/services/interfaces/safevalues';
+import {MockArtifactService} from '../../core/services/testing/mock-artifact.service';
+import {initTestBed} from '../../testing/utils';
+import {CHAT_PANEL_MESSAGES, ChatPanelMessagesInjectionToken} from '../chat-panel/chat-panel.component.i18n';
+import {MARKDOWN_COMPONENT} from '../markdown/markdown.component.interface';
+
+import {ContentBubbleComponent} from './content-bubble.component';
+
+@Component({selector: 'app-markdown', standalone: true, template: ''})
+class MockMarkdownComponent {
+  data = '';
+}
+
+describe('ContentBubbleComponent', () => {
+  let component: ContentBubbleComponent;
+  let fixture: ComponentFixture<ContentBubbleComponent>;
+
+  beforeEach(async () => {
+    initTestBed();
+
+    // The two renderers are stubbed: this spec is about which canvas is
+    // dispatched to, not what it draws. `getSurfaces` still needs a real Map --
+    // the v0.8 canvas calls `.has()` on it during ngOnChanges.
+    const mockMessageProcessor = jasmine.createSpyObj<MessageProcessor>(
+        'MessageProcessor', ['processMessages', 'getSurfaces']);
+    mockMessageProcessor.getSurfaces.and.returnValue(new Map());
+    const mockRenderer = jasmine.createSpyObj<A2uiRendererService>(
+        'A2uiRendererService', ['processMessages'],
+        {surfaceGroup: {getSurface: () => undefined} as any});
+
+    await TestBed
+        .configureTestingModule({
+          imports: [
+            ContentBubbleComponent, NoopAnimationsModule, HttpClientTestingModule
+          ],
+          providers: [
+            {
+              provide: ChatPanelMessagesInjectionToken,
+              useValue: CHAT_PANEL_MESSAGES
+            },
+            {provide: MARKDOWN_COMPONENT, useValue: MockMarkdownComponent},
+            {
+              provide: SAFE_VALUES_SERVICE,
+              useValue: {bypassSecurityTrustHtml: (v: string) => v}
+            },
+            {provide: ARTIFACT_SERVICE, useValue: new MockArtifactService()},
+            {provide: MessageProcessor, useValue: mockMessageProcessor},
+            {provide: A2uiRendererService, useValue: mockRenderer},
+          ],
+        })
+        .compileComponents();
+
+    fixture = TestBed.createComponent(ContentBubbleComponent);
+    component = fixture.componentInstance;
+  });
+
+  /** Renders a bot bubble carrying the given a2uiData. */
+  const renderWith = (a2uiData: unknown) => {
+    component.uiEvent =
+        new UiEvent({role: 'bot', a2uiData, event: {id: 'e1'} as any});
+    component.role = 'bot';
+    fixture.detectChanges();
+  };
+
+  const canvasV08 = () =>
+      fixture.nativeElement.querySelector('app-a2ui-canvas');
+  const canvasV09 = () =>
+      fixture.nativeElement.querySelector('app-a2ui-canvas-v09');
+
+  it('should render only the v0.8 canvas for a v0.8 payload', () => {
+    const beginRendering = {beginRendering: {surfaceId: 's1', root: 'root'}};
+    renderWith({
+      version: 'v0.8',
+      messages: [beginRendering],
+      surfaceId: 's1',
+      beginRendering,
+    });
+
+    expect(canvasV08()).not.toBeNull();
+    expect(canvasV09()).toBeNull();
+  });
+
+  it('should render only the v0.9 canvas for a v0.9 payload', () => {
+    renderWith({
+      version: 'v0.9',
+      messages: [{version: 'v0.9', createSurface: {surfaceId: 's9'}}],
+      surfaceId: 's9',
+    });
+
+    expect(canvasV09()).not.toBeNull();
+    expect(canvasV08()).toBeNull();
+  });
+
+  it('should render neither canvas when there is no a2uiData', () => {
+    renderWith(undefined);
+
+    expect(canvasV08()).toBeNull();
+    expect(canvasV09()).toBeNull();
+  });
+
+  it('should fall back to the v0.8 canvas for an untagged payload', () => {
+    // Defensive: anything that is not explicitly v0.9 keeps the historical
+    // rendering path.
+    renderWith({beginRendering: {beginRendering: {surfaceId: 's1'}}});
+
+    expect(canvasV08()).not.toBeNull();
+    expect(canvasV09()).toBeNull();
+  });
+});

--- a/src/app/components/content-bubble/content-bubble.component.ts
+++ b/src/app/components/content-bubble/content-bubble.component.ts
@@ -26,6 +26,7 @@ import {CustomJsonViewerComponent} from '../custom-json-viewer/custom-json-viewe
 import {UiEvent} from '../../core/models/UiEvent';
 import {SAFE_VALUES_SERVICE} from '../../core/services/interfaces/safevalues';
 import {JsonTooltipDirective} from '../../directives/html-tooltip.directive';
+import {A2uiCanvasV09Component} from '../a2ui-canvas/a2ui-canvas-v09.component';
 import {A2uiCanvasComponent} from '../a2ui-canvas/a2ui-canvas.component';
 import {MediaType} from '../artifact-tab/artifact-tab.component';
 import {AudioPlayerComponent} from '../audio-player/audio-player.component';
@@ -45,6 +46,7 @@ import { base64ToArrayBuffer, pcmToWavBlob } from '../../core/utils/audio';
     MatTooltipModule,
     CustomJsonViewerComponent,
     A2uiCanvasComponent,
+    A2uiCanvasV09Component,
     AudioPlayerComponent,
     JsonTooltipDirective,
   ],

--- a/src/app/core/constants/a2ui-theme.ts
+++ b/src/app/core/constants/a2ui-theme.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { Types, Styles } from '@a2ui/lit/0.8';
+// `Types` must come from @a2ui/angular so that it resolves to the same
+// @a2ui/web_core copy the renderer uses. @a2ui/lit carries its own nested,
+// older web_core, whose structurally-incompatible types are not assignable to
+// the renderer's. Only `Styles` (which @a2ui/angular does not re-export) comes
+// from @a2ui/lit.
+import { Types } from '@a2ui/angular/v0_8';
+import { Styles } from '@a2ui/lit/0.8';
 
 /** Elements */
 

--- a/src/app/core/models/A2uiPayload.ts
+++ b/src/app/core/models/A2uiPayload.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** The A2UI specification versions this app can render. */
+export type A2uiSpecVersion = 'v0.8'|'v0.9';
+
+/**
+ * Message kind keys defined by A2UI spec v0.8.
+ *
+ * Disjoint from `A2UI_V09_KINDS`, which is what makes version detection by
+ * kind key unambiguous for payloads that omit the `version` discriminator.
+ */
+export const A2UI_V08_KINDS = [
+  'beginRendering',
+  'surfaceUpdate',
+  'dataModelUpdate',
+] as const;
+
+/** Message kind keys defined by A2UI spec v0.9. */
+export const A2UI_V09_KINDS = [
+  'createSurface',
+  'updateComponents',
+  'updateDataModel',
+  'deleteSurface',
+] as const;
+
+/**
+ * A version-tagged batch of A2UI messages extracted from one event.
+ *
+ * `messages` is an ordered array rather than one slot per kind because v0.9
+ * legitimately sends N `updateComponents` / `updateDataModel` messages, which a
+ * fixed set of last-wins slots cannot represent.
+ */
+export interface A2uiPayload {
+  readonly version: A2uiSpecVersion;
+  /** De-enveloped messages, in send order. */
+  readonly messages: readonly unknown[];
+  /** The first surfaceId named by any message in the batch, if any. */
+  readonly surfaceId?: string;
+  /**
+   * v0.8-only aliases, populated only when `version === 'v0.8'`. Retained so
+   * the existing v0.8 render bindings stay unchanged.
+   */
+  readonly beginRendering?: unknown;
+  readonly surfaceUpdate?: unknown;
+  readonly dataModelUpdate?: unknown;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,10 @@
 
 
 import {Catalog, DEFAULT_CATALOG, provideMarkdownRenderer, Theme} from '@a2ui/angular/v0_8';
+import {A2UI_RENDERER_CONFIG, A2uiRendererService, BasicCatalog, provideMarkdownRenderer as provideV09MarkdownRenderer} from '@a2ui/angular/v0_9';
 import {Location} from '@angular/common';
 import {HttpClientModule} from '@angular/common/http';
-import {importProvidersFrom} from '@angular/core';
+import {importProvidersFrom, inject} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatButtonModule} from '@angular/material/button';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -128,6 +129,23 @@ fetch('./assets/config/runtime-config.json')
           // explicit provider the injection succeeds and then throws
           // "render is not a function" on the first Text component.
           provideMarkdownRenderer(),
+          // A2UI v0.9. Registered unconditionally alongside v0.8; which
+          // renderer draws a bubble is decided per payload, by its version.
+          // v0.9.1 has no provideA2Ui() (that arrives in 0.10), so the config
+          // token is registered by hand, and A2uiRendererService must be listed
+          // explicitly because it is a plain @Injectable() with no providedIn.
+          {
+            provide: A2UI_RENDERER_CONFIG,
+            useFactory: () => ({
+              catalogs: [inject(BasicCatalog)],
+              // TODO: route client actions back to the agent, mirroring the
+              // v0.8 MessageProcessor.events path.
+              actionHandler: (action: unknown) =>
+                  console.debug('A2UI v0.9 client action:', action),
+            })
+          },
+          A2uiRendererService,
+          provideV09MarkdownRenderer(),
           {provide: MARKDOWN_COMPONENT, useValue: MarkdownComponent},
           ...(config.logo ?
                   [{provide: LOGO_COMPONENT, useValue: CustomLogoComponent}] :

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@
  */
 
 
-import {Catalog, DEFAULT_CATALOG, Theme} from '@a2ui/angular';
+import {Catalog, DEFAULT_CATALOG, provideMarkdownRenderer, Theme} from '@a2ui/angular/v0_8';
 import {Location} from '@angular/common';
 import {HttpClientModule} from '@angular/common/http';
 import {importProvidersFrom} from '@angular/core';
@@ -123,6 +123,11 @@ fetch('./assets/config/runtime-config.json')
           {provide: LOCAL_FILE_SERVICE, useClass: LocalFileServiceImpl},
           {provide: Catalog, useValue: DEFAULT_CATALOG},
           {provide: Theme, useValue: A2UI_THEME},
+          // `Text` unconditionally injects `MarkdownRenderer`, whose base class
+          // is `providedIn: 'root'` but has no `render` method -- so without an
+          // explicit provider the injection succeeds and then throws
+          // "render is not a function" on the first Text component.
+          provideMarkdownRenderer(),
           {provide: MARKDOWN_COMPONENT, useValue: MarkdownComponent},
           ...(config.logo ?
                   [{provide: LOGO_COMPONENT, useValue: CustomLogoComponent}] :


### PR DESCRIPTION
## Summary

adk-web can currently render A2UI **spec 0.8** only. The renderer pins `@a2ui/angular@^0.8.3`, and both A2UI ingestion paths in `chat.component.ts` duck-type the 0.8 message kinds (`beginRendering`, `surfaceUpdate`, `dataModelUpdate`). An agent that emits **0.9** kinds (`createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`) is dropped silently — `a2uiData` is never populated, so nothing renders and no error surfaces anywhere.

This PR adds 0.9 support alongside 0.8, auto-detecting the spec version **per payload**, with no behavior change intended for existing 0.8 agents.

Motivating case: the [`staged-ui-widgets`](https://github.com/google/adk-samples/tree/main/contrib/python/staged-ui-widgets) sample in `adk-samples`, which pins `A2UI_VERSION = "0.9"` and emits `{"version": "v0.9", "createSurface": {...}}`.

> [!NOTE]
> **Draft:** the code is complete and CI-clean (678 unit tests green, `ng build` clean), but the manual browser verification in the checklist below has not been run yet. Marking ready once it passes. Design feedback very welcome in the meantime — particularly on the two questions at the bottom.

## Approach

**Version detection is per payload, not global.** A new `normalizeA2uiMessages` in `chat.component.ts` prefers the explicit `version` discriminator and falls back to kind-key matching (the two versions' kind keys are disjoint, so this is unambiguous). Both ingestion paths — A2A DataParts and the inline `<a2ui-json>` text block — route through it.

**The 0.8 renderer is not modified.** `A2uiCanvasComponent` and its bindings are untouched; 0.9 gets a sibling `A2uiCanvasV09Component` and `content-bubble.component.html` dispatches on `version`. The two renderers have genuinely different lifecycles — 0.8's `<a2ui-surface>` needs a resolved `[surface]` object re-read from a `Map` on every `ngOnChanges`, while 0.9's `<a2ui-v09-surface>` takes only a `surfaceId` and resolves internally in `ngOnInit` — so sharing one component would have meant branching inside it. Keeping 0.8 literally unmodified is also the airtight guarantee against 0.8 regressions: its spec needed no edits.

**Both renderers are always registered.** No conditional provider gating; dispatch is payload-driven.

`A2uiPayload.messages` is an array because 0.9 legitimately sends N `updateComponents`/`updateDataModel` messages across several surfaces, which the existing three-slot last-wins object cannot represent. The three 0.8 aliases (`beginRendering`/`surfaceUpdate`/`dataModelUpdate`) are still populated for 0.8 payloads so the 0.8 render binding stays byte-identical.

## Commits

Seven, each independently reviewable; the tree compiles and tests green at every step.

| | |
|---|---|
| 1 | `chore(deps)` — `package.json` only |
| 2 | `chore(deps)` — regenerated `package-lock.json` alone, so it can be collapsed |
| 3 | `refactor(a2ui)` — pin 0.8 imports to the `/v0_8` subpath; repair 0.8 regressions from the bump |
| 4 | `feat(a2ui)` — `A2uiPayload` + the normalizer. No rendering change yet |
| 5 | `feat(a2ui)` — the v0.9 canvas + `main.ts` providers. Not yet reachable from a template |
| 6 | `feat(a2ui)` — the content-bubble dispatch. **This is the commit that turns the feature on**; reverting it disables 0.9 without touching anything else |
| 7 | `feat(a2ui)` — the `--a2ui-*` theme block |

Commit 3 going green is the evidence that the 0.9 bump did not break 0.8. Please don't squash 4 into 6 — the normalizer carries the highest 0.8-regression risk and is worth keeping bisectable on its own.

## Dependencies

```diff
-    "@a2ui/angular": "^0.8.3",
+    "@a2ui/angular": "^0.9.1",
+    "@a2ui/lit": "^0.8.3",
+    "@a2ui/markdown-it": "^0.0.3",
```

- **`@a2ui/angular@0.9.1`** ships *both* versions via the `./v0_8` and `./v0_9` subpath exports, so this is additive rather than a migration. Peer is `@angular/core ^21.2.0` and the lockfile already resolves 21.2.4 — **no Angular bump**.
- **`@a2ui/lit@0.8.3`** is promoted transitive → direct. 0.9 drops it, which would break `a2ui-theme.ts`'s `Styles` import. `Styles.merge` cannot be hand-rolled to a spread: 8 of its 13 call sites merge *different* keys in the *same* `color-c-*` family, and a spread would leave two conflicting classes set.
- **`@a2ui/markdown-it@0.0.3`** is an *optional* peer, but `TextComponent` injects `MarkdownRenderer` unconditionally and `DefaultMarkdownRenderer` does a bare `await import('@a2ui/markdown-it')`, which esbuild errors on when undeclared.

`@a2ui/web_core` is deliberately **not** added. I verified with `tsc` that `Parameters<A2uiRendererService['processMessages']>[0][number]` resolves to the real `A2uiMessage` rather than degrading to `any`, so the direct dependency isn't needed.

## ⚠️ One 0.8 behavior change to flag

Commit 3 adds `provideMarkdownRenderer()` to `main.ts`. This is a **0.8 fix**, not 0.9 setup: `MarkdownRenderer` is `providedIn: 'root'` but its base class has **no `render` method**, so after the dep bump every 0.8 `Text` component threw `render is not a function` at `a2ui-angular-v0_8.mjs:1446`. The explicit provider swaps in `DefaultMarkdownRenderer`, which has it.

The side effect is that 0.8 `Text` now renders **real markdown** through `@a2ui/markdown-it` (with DOMPurify) instead of the regex passthrough. I confirmed `@a2ui/markdown-it` loads rather than falling back. This is a 0.8 *rendering* change and it's on the verification checklist below, but reviewers who know the 0.8 rendering expectations should look at it directly.

## Theming

v0.9 has **no theme object**. Unlike 0.8, which is themed in TypeScript through the `Theme` token, 0.9 injects no root stylesheet and defines no `a2ui-light`/`a2ui-dark` classes — every component styles itself with inline `var(--a2ui-X, <fallback>)`, and all but a handful of those fallbacks are hardcoded light-mode values (`#fff`, `#333`, `#ccc`). Without commit 7, 0.9 surfaces are unreadable in adk-web's default dark theme, so it's a correctness fix rather than a cosmetic one.

Commit 7 defines the ~50 `--a2ui-*` properties as `var(--mat-sys-*)`. Because `var()` resolves at *use* time, the layer is pure indirection: a theme flip repaints `--mat-sys-*`, which repaints `--a2ui-*`. No JavaScript, no new classes, one definition site — `ThemeService` and `styles.scss` are untouched. It's scoped to `:host` rather than a global stylesheet, which also avoids two `angular.json` edits and keeps `--a2ui-*` out of the global namespace of an app embedding the component.

Three findings from reading the compiled 0.9 CSS, each commented at its mapping:

- The six `--a2ui-font-size-*` properties are **mandatory**. Upstream reads them as bare `var(--a2ui-font-size-l)` with no fallback, and an undefined custom property invalidates the whole declaration — every heading would silently drop to the browser default.
- `--a2ui-color-on-secondary` is the foreground of the **default** button, over an `--a2ui-color-surface` background. It maps to `--mat-sys-on-surface`; the intuitive `--mat-sys-on-secondary-container` gives low-contrast text.
- Two spots can only be reached from outside, via `::ng-deep`: `.a2ui-button:disabled` hardcodes `#e9ecef`/`#6c757d` with no custom property, and the 0.9 `CheckBox` is a bare `<input type="checkbox">` without `appearance: none`, so its `--a2ui-checkbox-background`/`-border` variables are **inert** and it renders in the browser's own light-mode chrome. `accent-color` is the one property a native checkbox honours. Both overrides should be deleted once upstream tokenizes them.

## 📌 Integration gotcha for agent authors

`catalogId` is **required** on 0.9 `createSurface` and must equal `https://a2ui.org/specification/v0_9/basic_catalog.json`, or surface creation fails **silently** — a `console.warn` and an empty div. This is the single most likely thing to trip up an agent author.

Because that failure mode is invisible, `chat.component.spec.ts` wires the **real** 0.9 provider graph rather than a stub, and asserts `console.error` was **not** called on the happy path. That's what converts the silent degradation into a test failure.

## Tests

678 passing, up from 643 on `main`; `ng build` clean.

- **`chat.component.spec.ts`** — 15 table-driven `detectA2uiVersion` cases (envelope discriminator, kind-key fallback both ways, `{}`, unknown key, `null`, a string); a multi-message 0.9 fixture on both ingestion paths; `<a2ui-json>[]</a2ui-json>` leaves `a2uiData` undefined *and still strips the text*; a mixed-version batch warns.
- **`a2ui-canvas-v09.component.spec.ts`** (new) — dispatch and `surfaceId` derivation; no change record → no call; the same array reference twice → exactly one call; `surfaceId` derived from `updateComponents` alone (the cross-bubble streaming case); a redundant `createSurface` skipped so a history reload doesn't throw `Surface already exists`; a failed message contained without abandoning the rest of the batch; and the `@if` gate.
- **`content-bubble.component.spec.ts`** (new) — there was no spec for this component, and it's the file that catches a mis-dispatch. 0.8 → `app-a2ui-canvas` only; 0.9 → `app-a2ui-canvas-v09` only; absent `a2uiData` → neither; untagged → falls back to 0.8.

Two notes on deliberate test choices:

- The `@if (surfaceId())` gate in the 0.9 canvas template is **load-bearing, not cosmetic** — `ComponentHostComponent.ngOnInit` looks its surface up once and, on a miss, warns and **never retries** (a missing *component*, by contrast, recovers via `componentsModel.onCreated`). The gate guarantees `createSurface` has been processed before the child mounts, and there's a test for it.
- 0.9 fixtures are plain objects checked structurally, not `as unknown as <Type>` casts. The 0.8 spec uses those casts in four places, which erases all compile-time checking.

`chat-panel.component.spec.ts`'s A2UI test stays `xit`, now with a comment explaining why: chat-panel doesn't own the canvas (the chain is `chat-panel → event-row → event-content → content-bubble → a2ui-canvas`) and its TestBed provides none of the A2UI DI graph, so re-enabling it is high-cost and redundant with the new content-bubble spec.

## Verification checklist (outstanding — why this is a draft)

`npm test` and `ng build` are green. No unit test can catch a `catalogId` mismatch or 0.9's silent-degradation failure modes, so the following still needs a browser:

- [ ] A surface exercising Card / Button / TextField / Tabs / Modal / Slider / Checkbox, in **both** dark and light mode
- [ ] Toggling the theme *while* a surface is mounted (should be instant — pure CSS indirection)
- [ ] History reload of a session containing 0.9 surfaces
- [ ] Streaming where `createSurface` and `updateComponents` land in *different* events/bubbles
- [ ] An existing **0.8** agent still renders identically — including the markdown change flagged above
- [ ] Devtools console clean throughout; any `a2ui` warn/error treated as a failure

One known residual hazard I could not rule out by reading: if re-processing `createSurface` on a history reload constructs a *new* `SurfaceModel`, an already-mounted child holds a stale reference and blanks. The redundant-`createSurface` skip should prevent it. If the reload check shows a blank surface, the fix is a `surfaceGeneration` signal driving a keyed `@for` to force child recreation.

## Explicitly out of scope

- **`event.actions.render_ui_widgets` with `provider: "a2ui"`** — the `staged-ui-widgets` sample's *other* incompatibility. I checked and this is **not** a standard A2UI contract: zero references in the A2UI spec repo, and A2UI's own official ADK sample uses A2A DataParts. It looks like a standard *ADK* API rather than a standard *A2UI* one, which makes it a maintainer question — tracked on #447. This PR adds 0.9 vocabulary support only; the sample can be updated separately to deliver over the `<a2ui-json>` text block, which I verified renders live and not only on history reload.
- **Pre-existing latent issue** at `main.ts`: `{provide: Theme, useValue: A2UI_THEME}` supplies a plain object where the `Theme` *class* is expected. It works only because consumers read exactly the four fields `Theme` exposes and `A2UI_THEME` happens to have exactly those four (upstream's own `provideA2UI()` does `const t = new Theme(); t.update(config.theme)`). Left alone — changing it invites regressions unrelated to this PR.
- **Duplicate `zod` majors** in the bundle — the app uses 4.x, `web_core` needs `^3.25.76`. Already the status quo; npm nesting handles it and the two never meet at a type boundary. Deliberately **not** forcing a dedupe via `overrides`: zod 4 is not backward compatible and `web_core`'s schema parsing would break at runtime, silently. Happy to measure with `ng build --stats-json` as a follow-up if you'd like.

## Questions for maintainers

1. **`actionHandler` is a `console.debug` stub with a `TODO`.** 0.9 client actions (button clicks, field edits) are logged but not routed back to the agent. 0.8 does this through `MessageProcessor.events`. Should wiring that up land in this PR, or as a follow-up once the 0.9 rendering path is agreed? I left it out to keep this reviewable, and because the interactive round-trip deserves its own tests.
2. **`provideA2Ui()` does not exist in 0.9.1** (it arrives in 0.10.5), so `A2UI_RENDERER_CONFIG` is registered by hand and `A2uiRendererService` is listed explicitly — it's a plain `@Injectable()` with no `providedIn`, unlike 0.8's `MessageProcessor`. Would you rather target **0.10.x** now and use `provideA2Ui()`? I targeted 0.9 to match the spec version the sample pins, but that hand-rolled provider block is the part most likely to churn on the next upgrade.
