### PR TITLE
fix(chat): keep rendering session history when an A2A event has no content

### DIFF
--- a/src/app/components/chat/chat.component.spec.ts
+++ b/src/app/components/chat/chat.component.spec.ts
@@ -1739,6 +1739,21 @@ describe('ChatComponent', () => {
         });
   });
 
+  describe('buildUiEventFromEvent', () => {
+    it('should not throw for an A2A response event without content', () => {
+      const event = {
+        id: 'event-a2a-no-content',
+        author: 'remote_agent',
+        customMetadata: {'a2a:response': 'true'},
+      };
+
+      const uiEvent = (component as any).buildUiEventFromEvent(event);
+
+      expect(uiEvent.role).toBe('bot');
+      expect(uiEvent.text).toBeUndefined();
+    });
+  });
+
   describe('extractA2uiJsonFromText', () => {
     it('should do nothing if message has no text', () => {
       const uiEvent = new UiEvent({role: 'bot', event: {} as any});

--- a/src/app/components/chat/chat.component.ts
+++ b/src/app/components/chat/chat.component.ts
@@ -2719,7 +2719,7 @@ export class ChatComponent implements OnInit, AfterViewInit, OnDestroy {
   private buildUiEventFromEvent(event: any, reverseOrder: boolean = false): UiEvent {
     const isA2aResponse = this.isEventA2aResponse(event);
     const rawParts = isA2aResponse ?
-      this.combineA2uiDataParts(event.content?.parts) :
+      this.combineA2uiDataParts(event.content?.parts || []) :
       event.content?.parts || [];
     const parts = this.combineTextParts(rawParts);
     const partsToProcess = reverseOrder ? [...parts].reverse() : parts;


### PR DESCRIPTION
An A2A event carrying `a2a:response` metadata but no content made `buildUiEventFromEvent` throw. On session load the events are replayed in a bare `forEach`, so the throw aborted the replay and every event after that one was missing from the reloaded UI. Live streaming was unaffected, because that call site catches.

Default the parts to an empty array, as the streaming path already does.

Fixes #523
