### PR TITLE
docs: fix README install instructions and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Agent Development Kit (ADK) is a flexible and modular framework for developing a
 
 ADK web is the built-in dev UI that comes along with adk for easier development and debug.
 
-## ✨ Prerequisite
+## ✨ Prerequisites
 
 - **Install [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)**
 
-- **Install [NodeJs](https://nodejs.org/en)**
+- **Install [Node.js](https://nodejs.org/en)**
 
 - **Install [Angular CLI](https://angular.dev/tools/cli)**
 
@@ -43,7 +43,7 @@ adk-web folder:
 ### Install dependencies
 
 ```bash
-sudo npm install
+npm install
 ```
 
 ### Run adk web


### PR DESCRIPTION
Three small README fixes:

1. **Remove `sudo` from `npm install`**: running npm as root is unnecessary for this project and is explicitly discouraged by [npm's official docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) (risk of permission issues and security foot-guns). Local dependency installation does not need elevated privileges.

2. **"NodeJs" -> "Node.js"**: official spelling per nodejs.org.

3. **Heading "Prerequisite" -> "Prerequisites"**: the section lists multiple prerequisites.

Docs-only change, no code touched.